### PR TITLE
fix(oauth): Show network issue separately for auth errors

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -195,11 +195,5 @@ func GetTokens() (*Tokens, error) {
 
 func isNetworkError(err error) bool {
 	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return true
-	}
-
-	// Handle DNS resolution errors directly
-	var dnsErr *net.DNSError
-	return errors.As(err, &dnsErr)
+	return errors.As(err, &netErr)
 }


### PR DESCRIPTION
Fixes #80 to show network errors separately from the auth issues to refresh the token.