### PR TITLE
fix(app): Allow resizing of non-existent app in undeployed service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [X.X.X] - 2025-02-XX
+
+### Fixed
+
+* Resizing a non-existent service in an undeployed app no longer causes an error.
+
 ## [4.6.3] - 2024-11-04
 
 ### Fixed

--- a/app/app.go
+++ b/app/app.go
@@ -129,6 +129,9 @@ type DeployStatus struct {
 }
 
 func (d *DeployStatus) FindProcess(name string) (*Process, error) {
+	if d == nil {
+		return nil, fmt.Errorf("process '%s' not found", name)
+	}
 	for _, p := range d.Processes {
 		if p.Name == name {
 			return &p, nil


### PR DESCRIPTION
Fixes #89 

```
apppack ps resize web32323 --cpu 1 --memory 2G -a testbuildcache22
⚠  Service "web32323" does not exist. Settings will be used if the service is created later.

✔ resizing web32323
```

where `testbuildcache22` does not contain any builds at all.