### PR TITLE
Migrate cluster domain prompt from survey to huh

### DIFF
--- a/stacks/cluster.go
+++ b/stacks/cluster.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/apppackio/apppack/bridge"
 	"github.com/apppackio/apppack/ui"
@@ -19,6 +18,7 @@ import (
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/charmbracelet/huh"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
@@ -216,7 +216,6 @@ func (a *ClusterStack) SetDeletionProtection(cfg aws.Config, value bool) error {
 				},
 			},
 		})
-
 		if err != nil {
 			// If load balancer doesn't exist and we're turning deletion protection off,
 			// just log and continue (load balancer may have been manually deleted)
@@ -261,28 +260,40 @@ func (a *ClusterStack) UpdateFromFlags(flags *pflag.FlagSet) error {
 }
 
 func (a *ClusterStack) AskQuestions(_ aws.Config) error {
-	var questions []*ui.QuestionExtra
-
-	var err error
-
 	if a.Stack == nil {
-		questions = append(questions, []*ui.QuestionExtra{
-			{
-				Verbose:  "What domain should be associated with this cluster?",
-				HelpText: "Apps installed to this cluster will automatically get assigned a subdomain on the provided domain. The domain or a parent domain must already be setup as a Route53 Hosted Zone. See https://docs.apppack.io/how-to/bring-your-own-cluster-domain/ for more info.",
-				Question: &survey.Question{
-					Name:     "Domain",
-					Prompt:   &survey.Input{Message: "Cluster Domain", Default: a.Parameters.Domain},
-					Validate: survey.Required,
-				},
-			},
-		}...)
-		if err = ui.AskQuestions(questions, a.Parameters); err != nil {
+		form, domainPtr := ClusterDomainForm(a.Parameters.Domain)
+		if err := form.Run(); err != nil {
 			return err
 		}
+		a.Parameters.Domain = *domainPtr
 	}
 
 	return nil
+}
+
+// ClusterDomainForm builds the interactive form for entering the cluster domain.
+// Returns the form and a pointer to the entered domain value.
+func ClusterDomainForm(defaultDomain string) (*huh.Form, *string) {
+	domain := defaultDomain
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("What domain should be associated with this cluster?").
+				Description("Apps installed to this cluster will automatically get assigned a subdomain on the provided domain.\nThe domain or a parent domain must already be setup as a Route53 Hosted Zone.\nSee https://docs.apppack.io/how-to/bring-your-own-cluster-domain/ for more info."),
+			huh.NewInput().
+				Title("Cluster Domain").
+				Value(&domain).
+				Validate(func(s string) error {
+					if strings.TrimSpace(s) == "" {
+						return fmt.Errorf("domain is required")
+					}
+					return nil
+				}),
+		),
+	)
+
+	return form, &domain
 }
 
 func (*ClusterStack) StackName(name *string) *string {

--- a/stacks/cluster_test.go
+++ b/stacks/cluster_test.go
@@ -1,0 +1,31 @@
+package stacks
+
+import (
+	"testing"
+
+	"github.com/apppackio/apppack/ui/uitest"
+)
+
+func TestClusterDomainForm_EnterDomain(t *testing.T) {
+	form, domainPtr := ClusterDomainForm("")
+	tm := uitest.RunForm(t, form)
+	uitest.TypeAndSubmit(tm, "example.com")
+	uitest.WaitDone(t, tm)
+
+	if *domainPtr != "example.com" {
+		t.Errorf("expected 'example.com', got %q", *domainPtr)
+	}
+}
+
+func TestClusterDomainForm_DefaultDomain(t *testing.T) {
+	form, domainPtr := ClusterDomainForm("default.io")
+	tm := uitest.RunForm(t, form)
+	// Press Enter twice: once to pass the Note, once to accept the default Input
+	uitest.SelectFirst(tm)
+	uitest.SelectFirst(tm)
+	uitest.WaitDone(t, tm)
+
+	if *domainPtr != "default.io" {
+		t.Errorf("expected 'default.io', got %q", *domainPtr)
+	}
+}

--- a/testdata/script/create_cluster.txtar
+++ b/testdata/script/create_cluster.txtar
@@ -1,0 +1,6 @@
+# Test create cluster help output
+exec apppack create cluster --help
+stdout 'Creates an AppPack Cluster'
+stdout '\-\-cidr'
+stdout '\-\-domain'
+! stderr .


### PR DESCRIPTION
## Summary

- Migrate cluster domain input prompt from `survey` to `huh`
- Extract `ClusterDomainForm` as a pure form builder function
- Add teatest TUI tests and testscript CLI tests

Closes #118

## Changes

| File | Purpose |
|------|---------|
| `stacks/cluster.go` | Replace `ui.AskQuestions` with `huh` form; extract `ClusterDomainForm` |
| `stacks/cluster_test.go` | teatest tests (enter domain, accept default) |
| `testdata/script/create_cluster.txtar` | testscript for help output |