### PR TITLE
fix: update admins remove docs to show multiple email support

### DIFF
--- a/cmd/admins.go
+++ b/cmd/admins.go
@@ -110,12 +110,13 @@ var adminsAddCmd = &cobra.Command{
 
 // adminsRemoveCmd represents the admins remove command
 var adminsRemoveCmd = &cobra.Command{
-	Use:   "remove <email>",
-	Short: "remove an administrator from the account",
+	Use:   "remove <email>...",
+	Short: "remove administrators from the account",
 	Long: `*Requires admin permissions.*
-Updates the application Cloudformation stack to remove an administrators.`,
+Updates the account Cloudformation stack to remove administrators.`,
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.MinimumNArgs(1),
+	Example:               "apppack admins remove user1@example.com user2@example.com",
 	Run: func(_ *cobra.Command, args []string) {
 		for _, email := range args {
 			if !validateEmail(email) {


### PR DESCRIPTION
- Use string: `<email>` → `<email>...` (matches `admins add`)
- Short description: singular → plural
- Long description: fix "application" → "account", fix grammar
- Add example showing multiple emails

Closes #112