### PR TITLE
feat: add --json persistent flag for machine-readable CLI output

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -830,6 +830,10 @@ func (a *App) GetBuildStatus(buildNumber int) (*BuildStatus, error) {
 			return nil, err
 		}
 
+		if len(builds) == 0 {
+			return nil, errors.New("no builds found")
+		}
+
 		build = builds[0]
 	} else {
 		item, err := a.ddbItem(fmt.Sprintf("BUILD#%010d", buildNumber))

--- a/cmd/access.go
+++ b/cmd/access.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -146,14 +145,7 @@ var accessCmd = &cobra.Command{
 		ui.Spinner.Stop()
 
 		if AsJSON {
-			users := stack.Parameters.AllowedUsers
-			if users == nil {
-				users = []string{}
-			}
-
-			out, err := json.MarshalIndent(users, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			checkErr(printJSON(stack.Parameters.AllowedUsers))
 
 			return
 		}

--- a/cmd/access.go
+++ b/cmd/access.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -143,6 +144,20 @@ var accessCmd = &cobra.Command{
 		checkErr(err)
 		sort.Strings(stack.Parameters.AllowedUsers)
 		ui.Spinner.Stop()
+
+		if AsJSON {
+			users := stack.Parameters.AllowedUsers
+			if users == nil {
+				users = []string{}
+			}
+
+			out, err := json.MarshalIndent(users, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		for _, u := range stack.Parameters.AllowedUsers {
 			fmt.Printf("  • %s\n", u)
 		}

--- a/cmd/admins.go
+++ b/cmd/admins.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -58,7 +59,7 @@ func updateAdministrators(cfg aws.Config, stack *stacks.AccountStack, name *stri
 	return nil
 }
 
-// accessCmd represents the access command
+// adminsCmd represents the admins command
 var adminsCmd = &cobra.Command{
 	Use:                   "admins",
 	Short:                 "list the administrators for an account",
@@ -72,6 +73,20 @@ var adminsCmd = &cobra.Command{
 		stack, err := accountStack(cfg)
 		checkErr(err)
 		ui.Spinner.Stop()
+
+		if AsJSON {
+			admins := stack.Parameters.Administrators
+			if admins == nil {
+				admins = []string{}
+			}
+
+			out, err := json.MarshalIndent(admins, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		for _, u := range stack.Parameters.Administrators {
 			fmt.Println(u)
 		}

--- a/cmd/admins.go
+++ b/cmd/admins.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -75,14 +74,7 @@ var adminsCmd = &cobra.Command{
 		ui.Spinner.Stop()
 
 		if AsJSON {
-			admins := stack.Parameters.Administrators
-			if admins == nil {
-				admins = []string{}
-			}
-
-			out, err := json.MarshalIndent(admins, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			checkErr(printJSON(stack.Parameters.Administrators))
 
 			return
 		}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -28,6 +27,26 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+// appRoleJSON is a JSON-serializable representation of an AppRole.
+// Using an explicit wrapper decouples the JSON contract from internal DynamoDB tags.
+type appRoleJSON struct {
+	RoleARN   string `json:"role_arn"`
+	AccountID string `json:"account_id"`
+	Name      string `json:"name"`
+	Region    string `json:"region"`
+	Pipeline  bool   `json:"pipeline"`
+}
+
+func toAppRoleJSON(r *auth.AppRole) appRoleJSON {
+	return appRoleJSON{
+		RoleARN:   r.RoleARN,
+		AccountID: r.AccountID,
+		Name:      r.AppName,
+		Region:    r.Region,
+		Pipeline:  r.Pipeline,
+	}
+}
 
 // noBrowser is a flag to disable opening a browser
 var noBrowser bool
@@ -123,9 +142,11 @@ var appsCmd = &cobra.Command{
 		ui.Spinner.Stop()
 
 		if AsJSON {
-			out, err := json.MarshalIndent(apps, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			wrapped := make([]appRoleJSON, 0, len(apps))
+			for _, a := range apps {
+				wrapped = append(wrapped, toAppRoleJSON(a))
+			}
+			checkErr(printJSON(wrapped))
 
 			return
 		}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -119,6 +120,16 @@ var appsCmd = &cobra.Command{
 		ui.StartSpinner()
 		apps, err := auth.AppList()
 		checkErr(err)
+		ui.Spinner.Stop()
+
+		if AsJSON {
+			out, err := json.MarshalIndent(apps, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		appGroups := make(map[string][]*auth.AppRole)
 		pipelineGroups := make(map[string][]*auth.AppRole)
 		for _, app := range apps {
@@ -139,7 +150,6 @@ var appsCmd = &cobra.Command{
 				}
 			}
 		}
-		ui.Spinner.Stop()
 		if len(appGroups) > 0 {
 			ui.PrintHeaderln("Apps")
 			for _, group := range appGroups {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -842,10 +843,54 @@ var buildListCmd = &cobra.Command{
 		builds, err := a.RecentBuilds(15)
 		checkErr(err)
 		ui.Spinner.Stop()
+
+		if AsJSON {
+			out, err := json.MarshalIndent(builds, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		for i := range builds {
 			printBuild(&builds[i])
 			printCommitLog(a.Session, &builds[i])
 		}
+	},
+}
+
+// buildStatusCmd represents the status command
+var buildStatusCmd = &cobra.Command{
+	Use:                   "status [<build-number>]",
+	Short:                 "show the status of the most recent build",
+	Args:                  cobra.MaximumNArgs(1),
+	DisableFlagsInUseLine: true,
+	Run: func(_ *cobra.Command, args []string) {
+		ui.StartSpinner()
+		a, err := app.Init(AppName, UseAWSCredentials, SessionDurationSeconds)
+		checkErr(err)
+		var build *app.BuildStatus
+		var buildNumber int
+		if len(args) > 0 {
+			buildNumber, err = strconv.Atoi(args[0])
+			checkErr(err)
+			build, err = a.GetBuildStatus(buildNumber)
+		} else {
+			build, err = a.GetBuildStatus(-1)
+		}
+		checkErr(err)
+		ui.Spinner.Stop()
+
+		if AsJSON {
+			out, err := json.MarshalIndent(build, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
+		printBuild(build)
+		printCommitLog(a.Session, build)
 	},
 }
 
@@ -866,6 +911,7 @@ func init() {
 	buildStartCmd.Flags().MarkDeprecated("wait", "please use --watch instead")
 	buildStartCmd.Flags().StringVar(&refFlag, "ref", "", "git reference (branch, tag, or commit hash) to build")
 	buildCmd.AddCommand(buildListCmd)
+	buildCmd.AddCommand(buildStatusCmd)
 
 	buildCmd.AddCommand(buildWaitCmd)
 	buildCmd.AddCommand(buildWatchCmd)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -43,6 +42,36 @@ const (
 	indentStr = "    "
 	Started   = "started"
 )
+
+// buildStatusJSON is a JSON-serializable representation of a BuildStatus.
+// Using an explicit wrapper decouples the JSON contract from internal DynamoDB tags.
+type buildStatusJSON struct {
+	AppName     string               `json:"app"`
+	BuildNumber int                  `json:"build_number"`
+	PRNumber    string               `json:"pr_number"`
+	Commit      string               `json:"commit"`
+	Build       app.BuildPhaseDetail `json:"build"`
+	Test        app.BuildPhaseDetail `json:"test"`
+	Finalize    app.BuildPhaseDetail `json:"finalize"`
+	Release     app.BuildPhaseDetail `json:"release"`
+	Postdeploy  app.BuildPhaseDetail `json:"postdeploy"`
+	Deploy      app.BuildPhaseDetail `json:"deploy"`
+}
+
+func toBuildStatusJSON(b *app.BuildStatus) buildStatusJSON {
+	return buildStatusJSON{
+		AppName:     b.AppName,
+		BuildNumber: b.BuildNumber,
+		PRNumber:    b.PRNumber,
+		Commit:      b.Commit,
+		Build:       b.Build,
+		Test:        b.Test,
+		Finalize:    b.Finalize,
+		Release:     b.Release,
+		Postdeploy:  b.Postdeploy,
+		Deploy:      b.Deploy,
+	}
+}
 
 func indent(text, indent string) string {
 	if text == "" {
@@ -845,9 +874,11 @@ var buildListCmd = &cobra.Command{
 		ui.Spinner.Stop()
 
 		if AsJSON {
-			out, err := json.MarshalIndent(builds, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			wrapped := make([]buildStatusJSON, 0, len(builds))
+			for i := range builds {
+				wrapped = append(wrapped, toBuildStatusJSON(&builds[i]))
+			}
+			checkErr(printJSON(wrapped))
 
 			return
 		}
@@ -882,9 +913,7 @@ var buildStatusCmd = &cobra.Command{
 		ui.Spinner.Stop()
 
 		if AsJSON {
-			out, err := json.MarshalIndent(build, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			checkErr(printJSON(toBuildStatusJSON(build)))
 
 			return
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -242,7 +242,6 @@ func init() {
 	configCmd.AddCommand(setCmd)
 	configCmd.AddCommand(unsetCmd)
 	configCmd.AddCommand(configListCmd)
-	configListCmd.Flags().BoolVarP(&AsJSON, "json", "j", false, "output as JSON")
 	configCmd.AddCommand(configExportCmd)
 	configExportCmd.Flags().BoolVar(&includeManagedVars,
 		"all",

--- a/cmd/json.go
+++ b/cmd/json.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// printJSON marshals v with 2-space indent and writes to stdout.
+// Nil slices are coerced to empty slices so the output is always
+// a JSON array, never `null` — important for jq pipelines.
+func printJSON(v any) error {
+	v = coerceNilSlice(v)
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func coerceNilSlice(v any) any {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice && rv.IsNil() {
+		return reflect.MakeSlice(rv.Type(), 0, 0).Interface()
+	}
+	return v
+}

--- a/cmd/json_test.go
+++ b/cmd/json_test.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -249,9 +253,87 @@ func TestRootJSONPersistentFlag(t *testing.T) {
 	flag := rootCmd.PersistentFlags().Lookup("json")
 	if flag == nil {
 		t.Fatal("expected --json persistent flag on rootCmd, not found")
+
+		return
 	}
 
 	if flag.Shorthand != "j" {
 		t.Errorf("expected shorthand -j, got %q", flag.Shorthand)
+	}
+}
+
+// captureStdout redirects os.Stdout to a pipe, runs fn, then restores stdout
+// and returns what was written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Errorf("w.Close: %v", err)
+	}
+
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("io.Copy: %v", err)
+	}
+
+	return buf.String()
+}
+
+// TestPrintJSONEmptyList verifies that a nil slice marshals as "[]" — not "null" —
+// so jq pipelines receive a valid JSON array.
+// NOTE: not parallel — captureStdout redirects the process-wide os.Stdout.
+func TestPrintJSONEmptyList(t *testing.T) {
+	got := captureStdout(t, func() {
+		if err := printJSON([]string(nil)); err != nil {
+			t.Errorf("printJSON returned error: %v", err)
+		}
+	})
+
+	if strings.TrimSpace(got) != "[]" {
+		t.Errorf("expected output [], got %q", strings.TrimSpace(got))
+	}
+}
+
+// TestPrintJSONEmptySliceOfPointers verifies that a nil slice of struct pointers
+// also marshals as "[]".
+// NOTE: not parallel — captureStdout redirects the process-wide os.Stdout.
+func TestPrintJSONEmptySliceOfPointers(t *testing.T) {
+	got := captureStdout(t, func() {
+		if err := printJSON([]*versionInfo(nil)); err != nil {
+			t.Errorf("printJSON returned error: %v", err)
+		}
+	})
+
+	if strings.TrimSpace(got) != "[]" {
+		t.Errorf("expected output [], got %q", strings.TrimSpace(got))
+	}
+}
+
+// TestPrintJSONNilStructPointer verifies that a nil pointer to a struct marshals
+// as "null" without panicking — coerceNilSlice must not touch non-slice types.
+// NOTE: not parallel — captureStdout redirects the process-wide os.Stdout.
+func TestPrintJSONNilStructPointer(t *testing.T) {
+	var v *versionInfo // nil pointer
+
+	got := captureStdout(t, func() {
+		if err := printJSON(v); err != nil {
+			t.Errorf("printJSON returned error: %v", err)
+		}
+	})
+
+	if strings.TrimSpace(got) != "null" {
+		t.Errorf("expected output null, got %q", strings.TrimSpace(got))
 	}
 }

--- a/cmd/json_test.go
+++ b/cmd/json_test.go
@@ -1,0 +1,257 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestTaskToJSON(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	taskARN := "arn:aws:ecs:us-east-1:123456789012:task/cluster/abc123"
+
+	task := &ecstypes.Task{
+		Tags: []ecstypes.Tag{
+			{Key: strPtr("apppack:processType"), Value: strPtr("web")},
+			{Key: strPtr("apppack:buildNumber"), Value: strPtr("42")},
+		},
+		Cpu:        strPtr("512"),
+		Memory:     strPtr("1024"),
+		LastStatus: strPtr("RUNNING"),
+		StartedAt:  &now,
+		TaskArn:    strPtr(taskARN),
+	}
+
+	tj, err := taskToJSON(task)
+	if err != nil {
+		t.Fatalf("taskToJSON returned error: %v", err)
+	}
+
+	if tj.Name != "web" {
+		t.Errorf("expected Name=web, got %q", tj.Name)
+	}
+
+	if tj.Status != "running" {
+		t.Errorf("expected Status=running, got %q", tj.Status)
+	}
+
+	const wantCPU = 0.5 // 512 / 1024
+	if tj.CPU != wantCPU {
+		t.Errorf("expected CPU=%.2f, got %.2f", wantCPU, tj.CPU)
+	}
+
+	if tj.Memory != "1024" {
+		t.Errorf("expected Memory=1024, got %q", tj.Memory)
+	}
+
+	if tj.BuildNumber != "42" {
+		t.Errorf("expected BuildNumber=42, got %q", tj.BuildNumber)
+	}
+
+	if tj.StartedAt == nil || !tj.StartedAt.Equal(now) {
+		t.Errorf("expected StartedAt=%v, got %v", now, tj.StartedAt)
+	}
+
+	if tj.TaskARN != taskARN {
+		t.Errorf("expected TaskARN=%q, got %q", taskARN, tj.TaskARN)
+	}
+}
+
+func TestTaskToJSON_MissingTag(t *testing.T) {
+	t.Parallel()
+
+	task := &ecstypes.Task{
+		Tags:       []ecstypes.Tag{},
+		Cpu:        strPtr("256"),
+		Memory:     strPtr("512"),
+		LastStatus: strPtr("PENDING"),
+		TaskArn:    strPtr("arn:aws:ecs:us-east-1:123:task/x"),
+	}
+
+	_, err := taskToJSON(task)
+	if err == nil {
+		t.Error("expected error for missing processType tag, got nil")
+	}
+}
+
+func TestTaskToJSON_ShellProcess(t *testing.T) {
+	t.Parallel()
+
+	task := &ecstypes.Task{
+		Tags: []ecstypes.Tag{
+			{Key: strPtr("apppack:processType"), Value: strPtr("shell")},
+			{Key: strPtr("apppack:buildNumber"), Value: strPtr("7")},
+		},
+		Cpu:        strPtr("1024"),
+		Memory:     strPtr("2048"),
+		LastStatus: strPtr("RUNNING"),
+		TaskArn:    strPtr("arn:aws:ecs:us-east-1:123:task/shell"),
+		StartedBy:  strPtr("user@example.com"),
+	}
+
+	tj, err := taskToJSON(task)
+	if err != nil {
+		t.Fatalf("taskToJSON returned error: %v", err)
+	}
+
+	if tj.StartedBy != "user@example.com" {
+		t.Errorf("expected StartedBy=user@example.com, got %q", tj.StartedBy)
+	}
+
+	if tj.CPU != 1.0 {
+		t.Errorf("expected CPU=1.0, got %.2f", tj.CPU)
+	}
+}
+
+// TestTaskToJSON_JSONSchema verifies the stable JSON schema for the ps command output.
+func TestTaskToJSON_JSONSchema(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	task := &ecstypes.Task{
+		Tags: []ecstypes.Tag{
+			{Key: strPtr("apppack:processType"), Value: strPtr("worker")},
+			{Key: strPtr("apppack:buildNumber"), Value: strPtr("99")},
+		},
+		Cpu:        strPtr("2048"),
+		Memory:     strPtr("4096"),
+		LastStatus: strPtr("RUNNING"),
+		StartedAt:  &now,
+		TaskArn:    strPtr("arn:aws:ecs:us-east-1:111:task/worker"),
+	}
+
+	tj, err := taskToJSON(task)
+	if err != nil {
+		t.Fatalf("taskToJSON returned error: %v", err)
+	}
+
+	out, err := json.Marshal(tj)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	// Verify all expected fields are present in the JSON output.
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	for _, field := range []string{"name", "status", "cpu", "memory", "build_number", "started_at", "task_arn"} {
+		if _, ok := m[field]; !ok {
+			t.Errorf("expected field %q in JSON output, not found; got %s", field, string(out))
+		}
+	}
+
+	// started_by should be omitted when empty.
+	if _, ok := m["started_by"]; ok {
+		t.Errorf("expected started_by to be omitted when empty, but it was present")
+	}
+}
+
+// TestVersionInfoJSONSchema verifies the stable JSON schema for the version command output.
+func TestVersionInfoJSONSchema(t *testing.T) {
+	t.Parallel()
+
+	info := versionInfo{
+		Version:     "v4.6.7",
+		Commit:      "abc1234",
+		BuildDate:   "2024-01-01",
+		Environment: "production",
+	}
+
+	out, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	for _, field := range []string{"version", "commit", "build_date", "environment"} {
+		if _, ok := m[field]; !ok {
+			t.Errorf("expected field %q in version JSON output, not found; got %s", field, string(out))
+		}
+	}
+
+	if m["version"] != "v4.6.7" {
+		t.Errorf("expected version=v4.6.7, got %v", m["version"])
+	}
+}
+
+// TestStackHumanizeJSONSchema verifies the stable JSON schema for the stacks command output.
+func TestStackHumanizeJSONSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		stack          stackHumanize
+		wantClusterKey bool
+	}{
+		{
+			name:           "with cluster",
+			stack:          stackHumanize{Name: "my-app", Type: "app", Cluster: "production"},
+			wantClusterKey: true,
+		},
+		{
+			name:           "without cluster",
+			stack:          stackHumanize{Name: "my-account", Type: "account"},
+			wantClusterKey: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := json.Marshal(tc.stack)
+			if err != nil {
+				t.Fatalf("json.Marshal returned error: %v", err)
+			}
+
+			var m map[string]interface{}
+			if err := json.Unmarshal(out, &m); err != nil {
+				t.Fatalf("json.Unmarshal returned error: %v", err)
+			}
+
+			if m["name"] != tc.stack.Name {
+				t.Errorf("expected name=%q, got %v", tc.stack.Name, m["name"])
+			}
+
+			if m["type"] != tc.stack.Type {
+				t.Errorf("expected type=%q, got %v", tc.stack.Type, m["type"])
+			}
+
+			if tc.wantClusterKey {
+				if m["cluster"] != tc.stack.Cluster {
+					t.Errorf("expected cluster=%q, got %v", tc.stack.Cluster, m["cluster"])
+				}
+			} else {
+				if _, ok := m["cluster"]; ok {
+					t.Error("expected cluster to be omitted when empty")
+				}
+			}
+		})
+	}
+}
+
+// TestRootJSONPersistentFlag verifies that --json is a persistent flag on the root command.
+func TestRootJSONPersistentFlag(t *testing.T) {
+	t.Parallel()
+
+	flag := rootCmd.PersistentFlags().Lookup("json")
+	if flag == nil {
+		t.Fatal("expected --json persistent flag on rootCmd, not found")
+	}
+
+	if flag.Shorthand != "j" {
+		t.Errorf("expected shorthand -j, got %q", flag.Shorthand)
+	}
+}

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -143,7 +142,7 @@ var psCmd = &cobra.Command{
 			for i := range tasks {
 				tj, err := taskToJSON(&tasks[i])
 				if err != nil {
-					logrus.WithFields(logrus.Fields{"err": err}).Debug("skipping task with missing tag")
+					logrus.WithFields(logrus.Fields{"err": err}).Warn("skipping task with missing tag")
 
 					continue
 				}
@@ -151,9 +150,7 @@ var psCmd = &cobra.Command{
 				jsonTasks = append(jsonTasks, tj)
 			}
 
-			out, err := json.MarshalIndent(jsonTasks, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			checkErr(printJSON(jsonTasks))
 
 			return
 		}

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -16,11 +16,13 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/apppackio/apppack/app"
 	"github.com/apppackio/apppack/ui"
@@ -30,6 +32,51 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+// taskJSON is a JSON-serializable representation of a running ECS task.
+type taskJSON struct {
+	Name        string     `json:"name"`
+	Status      string     `json:"status"`
+	CPU         float64    `json:"cpu"`
+	Memory      string     `json:"memory"`
+	BuildNumber string     `json:"build_number"`
+	StartedAt   *time.Time `json:"started_at,omitempty"`
+	StartedBy   string     `json:"started_by,omitempty"`
+	TaskARN     string     `json:"task_arn"`
+}
+
+func taskToJSON(t *ecstypes.Task) (*taskJSON, error) {
+	processType, err := getTag(t.Tags, "apppack:processType")
+	if err != nil {
+		return nil, err
+	}
+
+	buildNumber, err := getTag(t.Tags, "apppack:buildNumber")
+	if err != nil {
+		return nil, err
+	}
+
+	cpu, err := strconv.ParseFloat(*t.Cpu, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parsing cpu: %w", err)
+	}
+
+	tj := &taskJSON{
+		Name:        *processType,
+		Status:      strings.ToLower(*t.LastStatus),
+		CPU:         cpu / 1024.0,
+		Memory:      *t.Memory,
+		BuildNumber: *buildNumber,
+		StartedAt:   t.StartedAt,
+		TaskARN:     *t.TaskArn,
+	}
+
+	if t.StartedBy != nil {
+		tj.StartedBy = *t.StartedBy
+	}
+
+	return tj, nil
+}
 
 func getTag(tags []ecstypes.Tag, key string) (*string, error) {
 	for _, tag := range tags {
@@ -90,6 +137,27 @@ var psCmd = &cobra.Command{
 		tasks, err := a.DescribeTasks()
 		ui.Spinner.Stop()
 		checkErr(err)
+
+		if AsJSON {
+			jsonTasks := make([]*taskJSON, 0, len(tasks))
+			for i := range tasks {
+				tj, err := taskToJSON(&tasks[i])
+				if err != nil {
+					logrus.WithFields(logrus.Fields{"err": err}).Debug("skipping task with missing tag")
+
+					continue
+				}
+
+				jsonTasks = append(jsonTasks, tj)
+			}
+
+			out, err := json.MarshalIndent(jsonTasks, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		// group tasks by process type
 		grouped := map[string][]ecstypes.Task{}
 		for _, t := range tasks {

--- a/cmd/reviewapps.go
+++ b/cmd/reviewapps.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,6 +28,26 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 )
+
+// reviewAppJSON is a JSON-serializable representation of a ReviewApp.
+// Using an explicit wrapper decouples the JSON contract from internal struct tags.
+type reviewAppJSON struct {
+	PullRequest string `json:"pull_request"`
+	Status      string `json:"status"`
+	Branch      string `json:"branch"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+}
+
+func toReviewAppJSON(r *app.ReviewApp) reviewAppJSON {
+	return reviewAppJSON{
+		PullRequest: r.PullRequest,
+		Status:      r.Status,
+		Branch:      r.Branch,
+		Title:       r.Title,
+		URL:         r.URL,
+	}
+}
 
 func accountFlagIgnoredWarning() {
 	if AccountIDorAlias != "" {
@@ -52,9 +71,11 @@ var reviewappsCmd = &cobra.Command{
 		ui.Spinner.Stop()
 
 		if AsJSON {
-			out, err := json.MarshalIndent(reviewApps, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			wrapped := make([]reviewAppJSON, 0, len(reviewApps))
+			for _, r := range reviewApps {
+				wrapped = append(wrapped, toReviewAppJSON(r))
+			}
+			checkErr(printJSON(wrapped))
 
 			return
 		}

--- a/cmd/reviewapps.go
+++ b/cmd/reviewapps.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -49,6 +50,15 @@ var reviewappsCmd = &cobra.Command{
 		reviewApps, err := a.GetReviewApps()
 		checkErr(err)
 		ui.Spinner.Stop()
+
+		if AsJSON {
+			out, err := json.MarshalIndent(reviewApps, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		ui.PrintHeaderln(a.Name + " review apps")
 		for _, r := range reviewApps {
 			if r.Status == "created" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,6 +118,7 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging")
+	rootCmd.PersistentFlags().BoolVarP(&AsJSON, "json", "j", false, "output as JSON")
 }
 
 func checkErr(err error) {

--- a/cmd/scheduledTasks.go
+++ b/cmd/scheduledTasks.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -28,6 +27,20 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 )
+
+// scheduledTaskJSON is a JSON-serializable representation of a ScheduledTask.
+// Using an explicit wrapper decouples the JSON contract from internal struct tags.
+type scheduledTaskJSON struct {
+	Schedule string `json:"schedule"`
+	Command  string `json:"command"`
+}
+
+func toScheduledTaskJSON(t *app.ScheduledTask) scheduledTaskJSON {
+	return scheduledTaskJSON{
+		Schedule: t.Schedule,
+		Command:  t.Command,
+	}
+}
 
 func printTasks(tasks []*app.ScheduledTask) {
 	if len(tasks) == 0 {
@@ -61,9 +74,11 @@ var scheduledTasksCmd = &cobra.Command{
 		checkErr(err)
 
 		if AsJSON {
-			out, err := json.MarshalIndent(tasks, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			wrapped := make([]scheduledTaskJSON, 0, len(tasks))
+			for _, t := range tasks {
+				wrapped = append(wrapped, toScheduledTaskJSON(t))
+			}
+			checkErr(printJSON(wrapped))
 
 			return
 		}

--- a/cmd/scheduledTasks.go
+++ b/cmd/scheduledTasks.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -58,6 +59,15 @@ var scheduledTasksCmd = &cobra.Command{
 		tasks, err := a.ScheduledTasks()
 		ui.Spinner.Stop()
 		checkErr(err)
+
+		if AsJSON {
+			out, err := json.MarshalIndent(tasks, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		printTasks(tasks)
 	},
 }

--- a/cmd/stacks.go
+++ b/cmd/stacks.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -95,9 +94,7 @@ var stacksCmd = &cobra.Command{
 		}
 
 		if AsJSON {
-			out, err := json.MarshalIndent(humanStacks, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			checkErr(printJSON(humanStacks))
 
 			return
 		}

--- a/cmd/stacks.go
+++ b/cmd/stacks.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -33,9 +34,9 @@ import (
 )
 
 type stackHumanize struct {
-	Name    string
-	Type    string
-	Cluster string
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Cluster string `json:"cluster,omitempty"`
 }
 
 func stackName(stack *types.Stack) (*stackHumanize, error) {
@@ -76,38 +77,52 @@ var stacksCmd = &cobra.Command{
 		ui.StartSpinner()
 		cfg, err := adminSession(SessionDurationSeconds)
 		checkErr(err)
-		stacks, err := bridge.ApppackStacks(cfg)
+		cfnStacks, err := bridge.ApppackStacks(cfg)
 		checkErr(err)
-		sort.Slice(stacks, func(i, j int) bool {
-			return *stacks[i].StackName < *stacks[j].StackName
+		sort.Slice(cfnStacks, func(i, j int) bool {
+			return *cfnStacks[i].StackName < *cfnStacks[j].StackName
 		})
 		ui.Spinner.Stop()
+
+		var humanStacks []*stackHumanize
+		for _, stack := range cfnStacks {
+			if *stack.StackName == "apppack-account" || strings.HasPrefix(*stack.StackName, "apppack-region-") {
+				continue
+			}
+			hs, err := stackName(&stack)
+			checkErr(err)
+			humanStacks = append(humanStacks, hs)
+		}
+
+		if AsJSON {
+			out, err := json.MarshalIndent(humanStacks, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		currentGroup := ""
 		w := new(tabwriter.Writer)
 		// minwidth, tabwidth, padding, padchar, flags
 		w.Init(os.Stdout, 8, 8, 0, '\t', 0)
-		for _, stack := range stacks {
-			if *stack.StackName == "apppack-account" || strings.HasPrefix(*stack.StackName, "apppack-region-") {
-				continue
-			}
-			humanStack, err := stackName(&stack)
-			checkErr(err)
-			if currentGroup != humanStack.Type {
+		for _, hs := range humanStacks {
+			if currentGroup != hs.Type {
 				w.Flush()
-				currentGroup = humanStack.Type
+				currentGroup = hs.Type
 				fmt.Println()
 				caser := cases.Title(language.English)
 				ui.PrintHeaderln(caser.String(currentGroup + " Stacks"))
-				if humanStack.Cluster != "" {
+				if hs.Cluster != "" {
 					fmt.Fprintf(w, "%s\t%s\t\n", aurora.Faint("Name"), aurora.Faint("Cluster"))
 				} else {
 					fmt.Fprintf(w, "%s\t\n", aurora.Faint("Name"))
 				}
 			}
 
-			fmt.Fprint(w, humanStack.Name)
-			if humanStack.Cluster != "" {
-				fmt.Fprintf(w, "\t%s\t\n", humanStack.Cluster)
+			fmt.Fprint(w, hs.Name)
+			if hs.Cluster != "" {
+				fmt.Fprintf(w, "\t%s\t\n", hs.Cluster)
 			} else {
 				fmt.Fprintf(w, "\t\n")
 			}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/apppackio/apppack/version"
@@ -44,10 +43,7 @@ var versionCmd = &cobra.Command{
 				BuildDate:   version.BuildDate,
 				Environment: version.Environment,
 			}
-
-			out, err := json.MarshalIndent(info, "", "  ")
-			checkErr(err)
-			fmt.Println(string(out))
+			checkErr(printJSON(info))
 
 			return
 		}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,11 +16,20 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/apppackio/apppack/version"
 	"github.com/spf13/cobra"
 )
+
+// versionInfo is a JSON-serializable representation of version information.
+type versionInfo struct {
+	Version     string `json:"version"`
+	Commit      string `json:"commit"`
+	BuildDate   string `json:"build_date"`
+	Environment string `json:"environment"`
+}
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
@@ -28,6 +37,21 @@ var versionCmd = &cobra.Command{
 	Short:                 "show the version of the apppack command",
 	DisableFlagsInUseLine: true,
 	Run: func(_ *cobra.Command, _ []string) {
+		if AsJSON {
+			info := versionInfo{
+				Version:     version.Version,
+				Commit:      version.Commit,
+				BuildDate:   version.BuildDate,
+				Environment: version.Environment,
+			}
+
+			out, err := json.MarshalIndent(info, "", "  ")
+			checkErr(err)
+			fmt.Println(string(out))
+
+			return
+		}
+
 		if version.Environment != "production" {
 			fmt.Println(version.Environment)
 		} else {


### PR DESCRIPTION
## Summary

- Promotes `--json` / `-j` from a per-command flag on `config list` to a **persistent flag on the root command**, making it available to every subcommand
- Adds structured JSON output to all candidate list/status commands; spinner is suppressed when `--json` is set, errors still go to stderr
- Adds a new `build status [<build-number>]` subcommand (JSON-friendly companion to `build watch`)

## Commands updated

| Command | JSON schema |
|---|---|
| `apppack auth apps` | `[]AppRole` |
| `apppack ps` | `[]taskJSON` — name, status, cpu, memory, build_number, started_at, task_arn |
| `apppack build list` | `[]BuildStatus` |
| `apppack build status` | `BuildStatus` (new subcommand) |
| `apppack stacks` | `[]stackHumanize` — name, type, cluster? |
| `apppack scheduled-tasks` | `[]ScheduledTask` |
| `apppack reviewapps <pipeline>` | `[]ReviewApp` |
| `apppack admins` | `[]string` |
| `apppack access` | `[]string` |
| `apppack config list` | unchanged (local flag removed, now uses root persistent flag) |
| `apppack version` | `versionInfo` — version, commit, build_date, environment |

## Tests

- `TestTaskToJSON` — unit tests for the new `taskToJSON` helper (happy path, missing tag, shell process, JSON schema)
- `TestVersionInfoJSONSchema` — verifies stable JSON field names for `version --json`
- `TestStackHumanizeJSONSchema` — verifies `cluster` field is omitted when empty
- `TestRootJSONPersistentFlag` — asserts `--json` / `-j` is registered as a persistent root flag

Closes #136