### PR TITLE
ci: drop nightly tag in goreleaser snapshot runs

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -13,6 +13,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Remove nightly tag locally
+        # The nightly workflow creates a `nightly` tag at HEAD daily. In snapshot
+        # mode, goreleaser picks it up as the current tag and fails because it
+        # isn't valid semver. Deleting it locally lets goreleaser fall back to
+        # the latest v* tag. No effect on tagged release runs.
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: git tag -d nightly 2>/dev/null || true
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
## Problem

Every PR and push since #132 fails the `goreleaser` job:

```
current_tag=nightly previous_tag=v4.6.7
release failed after 0s error=failed to parse tag 'nightly' as semver: Invalid Semantic Version
```

The nightly workflow tags HEAD as `nightly` daily. In snapshot mode, goreleaser picks that up as the current tag and chokes because it isn't semver.

## Fix

Delete the local `nightly` tag before invoking goreleaser in snapshot runs (PR/push). Goreleaser then falls back to the latest `v*` tag (`v4.6.7`). Tagged release runs (`refs/tags/v*`) are skipped by the `if:` and unaffected.

Example failing run: https://github.com/apppackio/apppack/actions/runs/25067949859/job/73440099067