### PR TITLE
ci: fix nightly workflow failing on non-semver tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,13 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Remove local nightly tag
+        if: steps.check.outputs.skip != 'true'
+        # GoReleaser auto-detects the nearest reachable tag and tries to parse
+        # it as semver. The `nightly` tag from the previous run is non-semver,
+        # so delete it locally before GoReleaser runs (it gets re-pushed below).
+        run: git tag -d nightly || true
+
       - name: Run GoReleaser (snapshot)
         if: steps.check.outputs.skip != 'true'
         uses: goreleaser/goreleaser-action@v5


### PR DESCRIPTION
## Summary

The nightly workflow fails after the first successful run because GoReleaser auto-detects the nearest reachable tag from HEAD and tries to parse it as semver — even in `--snapshot` mode. Once the previous run pushes the `nightly` tag, every subsequent run hits:

```
error=failed to parse tag 'nightly' as semver: Invalid Semantic Version
```

Fix: delete the local `nightly` tag before running GoReleaser so it falls back to the previous semver tag (e.g. `v4.6.7`). The tag is force-pushed back to the new HEAD later in the workflow, so this only affects the local checkout.

Failing run: https://github.com/apppackio/apppack/actions/runs/25230315118/job/73983937457