### PR TITLE
fix(ddb): add dynamodbav tags so SDK v2 unmarshals stack items

### DIFF
--- a/ddb/ddb.go
+++ b/ddb/ddb.go
@@ -14,17 +14,21 @@ import (
 	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
+// AWS SDK v2's `attributevalue` package only honors `dynamodbav` tags. SDK v1's
+// `dynamodbattribute` honored `json` tags as a fallback, which masked the
+// missing tags here until the v2 migration in #106. Without these, all
+// UnmarshalMap / UnmarshalListOfMaps calls return zero-valued structs.
 type stackItem struct {
-	PrimaryID   string `json:"primary_id"`
-	SecondaryID string `json:"secondary_id"`
-	Stack       Stack  `json:"value"`
+	PrimaryID   string `dynamodbav:"primary_id"`
+	SecondaryID string `dynamodbav:"secondary_id"`
+	Stack       Stack  `dynamodbav:"value"`
 }
 
 type Stack struct {
-	StackID        string `json:"stack_id"`
-	StackName      string `json:"stack_name"`
-	Name           string `json:"name"`
-	DatabaseEngine string `json:"engine"`
+	StackID        string `dynamodbav:"stack_id"`
+	StackName      string `dynamodbav:"stack_name"`
+	Name           string `dynamodbav:"name"`
+	DatabaseEngine string `dynamodbav:"engine"`
 }
 
 func GetClusterItem(cfg aws.Config, cluster *string, addon string, name *string) (*Stack, error) {

--- a/ddb/ddb_test.go
+++ b/ddb/ddb_test.go
@@ -1,0 +1,66 @@
+package ddb
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStackItemUnmarshal asserts that a DDB item matching what apppack writes
+// for a cluster registration unmarshals correctly into stackItem.
+//
+// Regression guard for the SDK v1→v2 migration (#106): SDK v2's attributevalue
+// package only honors `dynamodbav` tags. The struct previously used `json`
+// tags, which SDK v1 honored as a fallback but SDK v2 does not. The result
+// was every DDB read returning zero-valued structs.
+func TestStackItemUnmarshal(t *testing.T) {
+	// Shape mirrors what the cluster CloudFormation custom resource writes to
+	// the apppack DDB table: see formations/cluster/cluster.py — ClusterDdbItem.
+	item := map[string]dynamodbtypes.AttributeValue{
+		"primary_id":   &dynamodbtypes.AttributeValueMemberS{Value: "CLUSTERS"},
+		"secondary_id": &dynamodbtypes.AttributeValueMemberS{Value: "CLUSTER#apppack"},
+		"value": &dynamodbtypes.AttributeValueMemberM{
+			Value: map[string]dynamodbtypes.AttributeValue{
+				"name":       &dynamodbtypes.AttributeValueMemberS{Value: "apppack"},
+				"stack_name": &dynamodbtypes.AttributeValueMemberS{Value: "apppack-cluster-apppack"},
+				"stack_id":   &dynamodbtypes.AttributeValueMemberS{Value: "arn:aws:cloudformation:us-east-1:123456789012:stack/apppack-cluster-apppack/abc-def"},
+			},
+		},
+	}
+
+	var got stackItem
+	require.NoError(t, attributevalue.UnmarshalMap(item, &got))
+
+	assert.Equal(t, "CLUSTERS", got.PrimaryID)
+	assert.Equal(t, "CLUSTER#apppack", got.SecondaryID)
+	assert.Equal(t, "apppack", got.Stack.Name)
+	assert.Equal(t, "apppack-cluster-apppack", got.Stack.StackName)
+	assert.Equal(t, "arn:aws:cloudformation:us-east-1:123456789012:stack/apppack-cluster-apppack/abc-def", got.Stack.StackID)
+	assert.Empty(t, got.Stack.DatabaseEngine, "DatabaseEngine should be empty when not present in DDB")
+}
+
+// TestStackItemUnmarshalWithEngine covers the database/redis case where the
+// `engine` field is populated.
+func TestStackItemUnmarshalWithEngine(t *testing.T) {
+	item := map[string]dynamodbtypes.AttributeValue{
+		"primary_id":   &dynamodbtypes.AttributeValueMemberS{Value: "CLUSTERS"},
+		"secondary_id": &dynamodbtypes.AttributeValueMemberS{Value: "CLUSTER#apppack#DATABASE#sandbox-db"},
+		"value": &dynamodbtypes.AttributeValueMemberM{
+			Value: map[string]dynamodbtypes.AttributeValue{
+				"name":       &dynamodbtypes.AttributeValueMemberS{Value: "sandbox-db"},
+				"stack_name": &dynamodbtypes.AttributeValueMemberS{Value: "apppack-database-sandbox-db"},
+				"stack_id":   &dynamodbtypes.AttributeValueMemberS{Value: "arn:aws:cloudformation:us-east-1:123456789012:stack/apppack-database-sandbox-db/x"},
+				"engine":     &dynamodbtypes.AttributeValueMemberS{Value: "postgres"},
+			},
+		},
+	}
+
+	var got stackItem
+	require.NoError(t, attributevalue.UnmarshalMap(item, &got))
+
+	assert.Equal(t, "sandbox-db", got.Stack.Name)
+	assert.Equal(t, "postgres", got.Stack.DatabaseEngine)
+}

--- a/testdata/script/create_database.txtar
+++ b/testdata/script/create_database.txtar
@@ -1,0 +1,8 @@
+# Test create database help output
+exec apppack create database --help
+stdout 'Creates an AppPack Database'
+stdout '\-\-cluster'
+stdout '\-\-engine'
+stdout '\-\-instance-class'
+stdout '\-\-multi-az'
+! stderr .


### PR DESCRIPTION
SDK v2's `attributevalue` package only honors `dynamodbav` tags. SDK v1's `dynamodbattribute` honored `json` tags as a fallback, which masked the missing tags on `stackItem` / `Stack` until the v2 migration in #106. Result: every DDB unmarshal returned zero-valued structs, so the cluster select prompt rendered a single empty option and downstream stack creation failed with an empty `Name`.

Adds `dynamodbav` tags matching the existing `json` names, plus unit tests covering the `ListClusters` (no engine) and database (with engine) shapes.

Closes #141
