### PR TITLE
fix(shell): use bash -l only for buildpack apps

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -67,6 +68,13 @@ type App struct {
 	DeployStatus          *DeployStatus
 	PendingDeployStatuses []*DeployStatus
 	AWS                   apppackaws.Interface
+
+	shellOnce sync.Once
+	shellTask struct {
+		taskFamily string
+		tags       []ecstypes.Tag
+		err        error
+	}
 }
 
 // ReviewApp is a representation of a AppPack review app
@@ -343,27 +351,43 @@ func (a *App) TaskDefinition(name string) (*ecstypes.TaskDefinition, []ecstypes.
 	return task.TaskDefinition, task.Tags, nil
 }
 
-func buildSystemFromTaskTags(tags []ecstypes.Tag) *string {
-	for _, tag := range tags {
-		if *tag.Key == "apppack:buildSystem" {
-			return tag.Value
+// loadShellTask fetches and caches the shell task definition's family and tags.
+// The underlying AWS call runs at most once per App.
+func (a *App) loadShellTask() error {
+	a.shellOnce.Do(func() {
+		taskDefn, tags, err := a.TaskDefinition("shell")
+		if err != nil {
+			a.shellTask.err = err
+			return
 		}
-	}
-
-	emptyString := ""
-	return &emptyString
+		a.shellTask.taskFamily = *taskDefn.Family
+		a.shellTask.tags = tags
+	})
+	return a.shellTask.err
 }
 
-func (a *App) ShellTaskFamily() (*string, *string, error) {
-	taskDefn, tags, err := a.TaskDefinition("shell")
-
-	buildSystem := buildSystemFromTaskTags(tags)
-
-	if err != nil {
-		return nil, nil, err
+func (a *App) ShellTaskFamily() (*string, error) {
+	if err := a.loadShellTask(); err != nil {
+		return nil, err
 	}
+	return &a.shellTask.taskFamily, nil
+}
 
-	return taskDefn.Family, buildSystem, nil
+// IsBuildpack reports whether the app's shell runs on the buildpack build
+// system. A missing or empty build system tag is treated as buildpacks for
+// backwards compatibility with apps provisioned before the tag existed.
+func (a *App) IsBuildpack() (bool, error) {
+	if err := a.loadShellTask(); err != nil {
+		return false, err
+	}
+	buildSystem := ""
+	for _, tag := range a.shellTask.tags {
+		if *tag.Key == "apppack:buildSystem" {
+			buildSystem = *tag.Value
+			break
+		}
+	}
+	return buildSystem == "buildpacks" || buildSystem == "", nil
 }
 
 // URL is used to lookup the app url from settings

--- a/app/shelltask_test.go
+++ b/app/shelltask_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+// seedShellTask pre-populates the cached shell task definition and marks the
+// sync.Once consumed, so IsBuildpack/ShellTaskFamily read this data instead of
+// making an AWS call.
+func seedShellTask(family string, tags []ecstypes.Tag) *App {
+	a := &App{}
+	a.shellOnce.Do(func() {
+		a.shellTask.taskFamily = family
+		a.shellTask.tags = tags
+	})
+
+	return a
+}
+
+func buildSystemTag(value string) ecstypes.Tag {
+	return ecstypes.Tag{Key: aws.String("apppack:buildSystem"), Value: aws.String(value)}
+}
+
+func TestIsBuildpack(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tags []ecstypes.Tag
+		want bool
+	}{
+		{
+			name: "buildpacks tag",
+			tags: []ecstypes.Tag{buildSystemTag("buildpacks")},
+			want: true,
+		},
+		{
+			name: "empty tag value treated as buildpacks",
+			tags: []ecstypes.Tag{buildSystemTag("")},
+			want: true,
+		},
+		{
+			name: "missing tag treated as buildpacks",
+			tags: []ecstypes.Tag{{Key: aws.String("apppack:appName"), Value: aws.String("myapp")}},
+			want: true,
+		},
+		{
+			name: "no tags at all treated as buildpacks",
+			tags: nil,
+			want: true,
+		},
+		{
+			name: "docker build system",
+			tags: []ecstypes.Tag{buildSystemTag("docker")},
+			want: false,
+		},
+		{
+			name: "build system tag among others",
+			tags: []ecstypes.Tag{
+				{Key: aws.String("apppack:appName"), Value: aws.String("myapp")},
+				buildSystemTag("docker"),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := seedShellTask("myapp-shell", tt.tags)
+
+			got, err := a.IsBuildpack()
+			if err != nil {
+				t.Fatalf("IsBuildpack() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("IsBuildpack() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShellTaskFamily(t *testing.T) {
+	t.Parallel()
+
+	a := seedShellTask("myapp-shell", nil)
+
+	family, err := a.ShellTaskFamily()
+	if err != nil {
+		t.Fatalf("ShellTaskFamily() unexpected error: %v", err)
+	}
+	if family == nil {
+		t.Fatal("ShellTaskFamily() = nil, want pointer to \"myapp-shell\"")
+	}
+	if *family != "myapp-shell" {
+		t.Errorf("ShellTaskFamily() = %q, want %q", *family, "myapp-shell")
+	}
+}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -140,13 +140,14 @@ func humanToECSSizeConfiguration(cpu float64, memory string) (*app.ECSSizeConfig
 }
 
 func interactiveCmd(a *app.App, cmd string) {
-	taskFamily, buildSystem, err := a.ShellTaskFamily()
+	taskFamily, err := a.ShellTaskFamily()
 	checkErr(err)
 	size, err := humanToECSSizeConfiguration(shellCPU, shellMem)
 	checkErr(err)
 	checkErr(a.ValidateECSTaskSize(*size))
 
-	isBuildpack := *buildSystem == "buildpacks" || *buildSystem == ""
+	isBuildpack, err := a.IsBuildpack()
+	checkErr(err)
 	exec := cmd
 
 	if isBuildpack && !shellRoot {
@@ -211,7 +212,13 @@ var shellCmd = &cobra.Command{
 		ui.StartSpinner()
 		a, err := app.Init(AppName, UseAWSCredentials, MaxSessionDurationSeconds)
 		checkErr(err)
-		interactiveCmd(a, "bash -l")
+		isBuildpack, err := a.IsBuildpack()
+		checkErr(err)
+		shell := "bash"
+		if isBuildpack {
+			shell = "bash -l"
+		}
+		interactiveCmd(a, shell)
 	},
 }
 


### PR DESCRIPTION
Docker/Dockerfile-based apps may set PATH in the image. Launching the shell with `bash -l` sources /etc/profile, which can clobber that PATH. Reserve `bash -l` for buildpack apps (where the CNB launcher wants login-shell semantics) and use plain `bash` otherwise.

Refactor shell task lookup along the way: memoize the DescribeTaskDefinition call with sync.Once, and split ShellTaskFamily into focused ShellTaskFamily and IsBuildpack accessors so callers no longer discard half the return.