### PR TITLE
feat(stacks): use Code Connections for repo auth

### DIFF
--- a/stacks/app_pipeline.go
+++ b/stacks/app_pipeline.go
@@ -1039,30 +1039,28 @@ func VerifySourceCredentials(cfg aws.Config, repositoryType string) error {
 		}
 
 		ui.Spinner.Stop()
-		ui.PrintWarning("CodeBuild needs to be authenticated to access your repository at " + friendlySourceName)
-		fmt.Println("On the CodeBuild new project page:")
-		fmt.Printf("    1. Scroll to the %s section\n", aurora.Bold("Source"))
-		fmt.Printf("    2. Select %s for the %s\n", aurora.Bold(friendlySourceName), aurora.Bold("Source provider"))
-		fmt.Printf("    3. Keep the default %s\n", aurora.Bold("Connect using OAuth"))
-		fmt.Printf("    4. Click %s\n", aurora.Bold("Connect to "+friendlySourceName))
-		fmt.Printf("    5. Click %s in the popup window\n", aurora.Bold("Confirm"))
-		fmt.Printf("    6. %s You can close the browser window and continue with app setup here.\n\n", aurora.Bold("That's it!"))
-		newProjectURL := fmt.Sprintf("https://%s.console.aws.amazon.com/codesuite/codebuild/project/new", cfg.Region)
+		ui.PrintWarning("AppPack needs a connection to your repository at " + friendlySourceName)
+		fmt.Println("On the CodeBuild default source credentials page that opens:")
+		fmt.Printf("    1. Choose %s for %s\n", aurora.Bold("Manage default source credential"), aurora.Bold(friendlySourceName))
+		fmt.Printf("    2. Create (or select) a %s and finish authorizing it in your browser\n", aurora.Bold("connection"))
+		fmt.Printf("    3. Save it as the %s for %s\n", aurora.Bold("default source credential"), aurora.Bold(friendlySourceName))
+		fmt.Printf("    4. %s Close the browser window and continue with app setup here.\n\n", aurora.Bold("That's it!"))
+		defaultCredentialsURL := fmt.Sprintf("https://%s.console.aws.amazon.com/codesuite/codebuild/sourceCredentials/default", cfg.Region)
 
-		url, err := auth.GetConsoleURL(cfg, newProjectURL)
+		url, err := auth.GetConsoleURL(cfg, defaultCredentialsURL)
 		if err == nil && isatty.IsTerminal(os.Stdin.Fd()) {
-			fmt.Println("Opening the CodeBuild new project page now...")
+			fmt.Println("Opening the CodeBuild default source credentials page now...")
 
 			err = browser.OpenURL(*url)
 			if err != nil {
-				fmt.Println("Open this URL in your browser to view logs:")
+				fmt.Println("Open this URL in your browser:")
 				fmt.Println(*url)
 			}
 		} else {
-			fmt.Printf("Visit the following URL to authenticate: %s", newProjectURL)
+			fmt.Printf("Visit the following URL to authenticate: %s", defaultCredentialsURL)
 		}
 
-		ui.PauseUntilEnter("Finish authentication in your web browser then press ENTER to continue.")
+		ui.PauseUntilEnter("Finish connecting in your web browser then press ENTER to continue.")
 
 		return VerifySourceCredentials(cfg, repositoryType)
 	}


### PR DESCRIPTION
## What

Updates the source-credential prompt in `apppack create app` / `create pipeline` (`VerifySourceCredentials`) to guide users through AWS Code Connections instead of the legacy CodeBuild OAuth flow.

- Opens the CodeBuild **default source credentials** page (`.../codebuild/sourceCredentials/default`) in the cluster's region, replacing the old `.../codebuild/project/new` page.
- Rewrites the on-screen steps to the GitHub App connection flow ("Manage default source credential" → create/select a connection → save as the default source credential). Wording uses the actual console labels and is provider-neutral (GitHub and Bitbucket).
- Drops the stale "Connect using OAuth / Confirm popup" instructions.

## Why

The old new-project OAuth walkthrough no longer matches the AWS console and relied on a deprecated path. Closes #82.

## How it works

No template change required: the app's CodeBuild project specifies no source `Auth` of its own, so it uses the account-level **default source credential**. Saving a Code Connection as that default (what this prompt guides) is enough — confirmed by the AWS CodeBuild "GitHub App connections" docs, where the `ImportSourceCredentials --auth-type CODECONNECTIONS` call is the CLI equivalent of the console page we open.

## Testing

- `go build ./...`, `go vet ./stacks/`, `go test ./stacks/` all pass
- `gofmt` clean
- No tests referenced the old prompt text