### PR TITLE
chore: release 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.0] - 2026-06-24
+
 ### Added
 
-* `build start` command now accepts optional `--ref` flag to build from specific git references (branches, tags, or commit hashes).
+* `--json` persistent flag for machine-readable CLI output.
 * `modify app` command to update some parameters of application/pipeline stacks.
+* `build start` command now accepts optional `--ref` flag to build from specific git references (branches, tags, or commit hashes).
 
 ### Changed
 
-* Updated to Go 1.25.4 and refreshed dependencies.
+* `create app`/`create pipeline` now guide repository authentication through AWS Code Connections (GitHub App) instead of the deprecated CodeBuild OAuth flow.
+* Migrated interactive prompts from survey to huh.
+* Upgraded to AWS SDK for Go v2.
+* Updated to Go 1.25.4, upgraded go-jose to v4, and refreshed dependencies.
 
 ### Fixed
 
 * Fixed issue where a stack update could revert unexpected parameters to template defaults.
+* `ps resize` no longer prints a misleading warning for release/scheduler processes.
+* Fixed `destroy` retry exit code.
+* Handle `LoadBalancerNotFound` during cluster deletion.
+* Added DynamoDB attribute tags so the SDK v2 correctly unmarshals stack items.
 
 ## [4.6.7] - 2025-08-14
 


### PR DESCRIPTION
Cuts the 4.7.0 release. Moves the accumulated changes since v4.6.7 under `## [4.7.0]`, filled in from the git history (the `[Unreleased]` section had only a subset).

Highlights:

* Added `--json` flag, `modify app` command, and `build start --ref`.
* `create app`/`create pipeline` use AWS Code Connections (GitHub App) for repository authentication.
* Interactive prompts migrated from survey to huh.
* Upgraded to AWS SDK for Go v2 and Go 1.25.4.
* Fixes for `ps resize` warnings, `destroy` retry exit code, `LoadBalancerNotFound` during cluster deletion, and SDK v2 stack-item unmarshaling.

Tag `v4.7.0` after merge to trigger the GoReleaser release.