### PR TITLE
feat(shell): surface task size in --live selector and on connect

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -139,6 +139,37 @@ func humanToECSSizeConfiguration(cpu float64, memory string) (*app.ECSSizeConfig
 	return nil, errors.New("unexpected memory format -- it must end in 'M' (for MB) or 'G' (for GB)")
 }
 
+// formatTaskSize returns a human-readable string of a task's CPU and memory
+// allocation, e.g. "0.25 vCPU / 512 MB" or "1 vCPU / 2 GB".
+// It returns an empty string when the task's Cpu or Memory fields are absent
+// or cannot be parsed.
+func formatTaskSize(t *ecstypes.Task) string {
+	if t.Cpu == nil || t.Memory == nil {
+		return ""
+	}
+
+	cpuUnits, err := strconv.ParseFloat(*t.Cpu, 64)
+	if err != nil {
+		return ""
+	}
+
+	memMB, err := strconv.Atoi(*t.Memory)
+	if err != nil {
+		return ""
+	}
+
+	cpuStr := strconv.FormatFloat(cpuUnits/1024.0, 'f', -1, 64)
+
+	var memStr string
+	if memMB >= 1024 && memMB%1024 == 0 {
+		memStr = fmt.Sprintf("%d GB", memMB/1024)
+	} else {
+		memStr = fmt.Sprintf("%d MB", memMB)
+	}
+
+	return fmt.Sprintf("%s vCPU / %s", cpuStr, memStr)
+}
+
 func interactiveCmd(a *app.App, cmd string) {
 	taskFamily, buildSystem, err := a.ShellTaskFamily()
 	checkErr(err)
@@ -168,7 +199,11 @@ func interactiveCmd(a *app.App, cmd string) {
 			}
 
 			arnParts := strings.Split(*t.TaskArn, "/")
-			options = append(options, huh.NewOption(fmt.Sprintf("%s: %s", *tag, arnParts[len(arnParts)-1]), i))
+			label := fmt.Sprintf("%s: %s", *tag, arnParts[len(arnParts)-1])
+			if sizeStr := formatTaskSize(&t); sizeStr != "" {
+				label = fmt.Sprintf("%s: %s  (%s)", *tag, arnParts[len(arnParts)-1], sizeStr)
+			}
+			options = append(options, huh.NewOption(label, i))
 		}
 
 		ui.Spinner.Stop()
@@ -178,15 +213,25 @@ func interactiveCmd(a *app.App, cmd string) {
 
 		ui.StartSpinner()
 
-		ecsSession, err := a.CreateEcsSession(
-			&tasks[*idxPtr],
-			exec,
-		)
+		selectedTask := &tasks[*idxPtr]
+		ecsSession, err := a.CreateEcsSession(selectedTask, exec)
 		checkErr(err)
 		ui.Spinner.Stop()
 
+		// Surface the live container's size before handing off the terminal.
+		if sizeStr := formatTaskSize(selectedTask); sizeStr != "" {
+			if processType, tagErr := getTag(selectedTask.Tags, "apppack:processType"); tagErr == nil {
+				fmt.Println(aurora.Faint(fmt.Sprintf(
+					"Attached to %s (%s). This is the live process's container — heavy commands may exhaust it. For a dedicated, right-sizable shell, use `apppack shell --cpu <n> --memory <n>`.",
+					*processType, sizeStr,
+				)))
+			}
+		}
+
 		err = a.ConnectToEcsSession(ecsSession)
 		checkErr(err)
+
+		return
 	}
 
 	var taskCommandPrefix []string

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -4,8 +4,98 @@ import (
 	"testing"
 
 	"github.com/apppackio/apppack/ui/uitest"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/charmbracelet/huh"
 )
+
+func TestFormatTaskSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cpu  *string
+		mem  *string
+		want string
+	}{
+		{
+			name: "quarter cpu 512 MB",
+			cpu:  aws.String("256"),
+			mem:  aws.String("512"),
+			want: "0.25 vCPU / 512 MB",
+		},
+		{
+			name: "half cpu 1 GB",
+			cpu:  aws.String("512"),
+			mem:  aws.String("1024"),
+			want: "0.5 vCPU / 1 GB",
+		},
+		{
+			name: "1 cpu 2 GB",
+			cpu:  aws.String("1024"),
+			mem:  aws.String("2048"),
+			want: "1 vCPU / 2 GB",
+		},
+		{
+			name: "2 cpu 4 GB",
+			cpu:  aws.String("2048"),
+			mem:  aws.String("4096"),
+			want: "2 vCPU / 4 GB",
+		},
+		{
+			name: "16 cpu 32 GB",
+			cpu:  aws.String("16384"),
+			mem:  aws.String("32768"),
+			want: "16 vCPU / 32 GB",
+		},
+		{
+			name: "memory not divisible by 1 GB stays in MB",
+			cpu:  aws.String("256"),
+			mem:  aws.String("768"),
+			want: "0.25 vCPU / 768 MB",
+		},
+		{
+			name: "nil cpu returns empty string",
+			cpu:  nil,
+			mem:  aws.String("1024"),
+			want: "",
+		},
+		{
+			name: "nil memory returns empty string",
+			cpu:  aws.String("512"),
+			mem:  nil,
+			want: "",
+		},
+		{
+			name: "invalid cpu returns empty string",
+			cpu:  aws.String("notanumber"),
+			mem:  aws.String("1024"),
+			want: "",
+		},
+		{
+			name: "invalid memory returns empty string",
+			cpu:  aws.String("512"),
+			mem:  aws.String("notanumber"),
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			task := &ecstypes.Task{
+				Cpu:    tc.cpu,
+				Memory: tc.mem,
+			}
+
+			got := formatTaskSize(task)
+			if got != tc.want {
+				t.Errorf("formatTaskSize() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestShellTaskSelectForm_SelectFirst(t *testing.T) {
 	options := []huh.Option[int]{


### PR DESCRIPTION
## Summary

- Adds formatTaskSize() helper that converts ECS CPU units and memory MB into human-readable strings (e.g. 0.5 vCPU / 1 GB)
- Inline size info in the huh selector for shell --live / ps exec --live so users know the container allocation before attaching
- Prints a one-line advisory after connecting that names the process type, its size, and nudges heavy workloads toward a dedicated shell with --cpu/--memory
- Fixes a pre-existing fall-through bug: adds return after the --live block so execution no longer falls into StartInteractiveShell once the live session ends

Closes #150

## Test plan

- go test ./cmd/ -- TestFormatTaskSize covers all CPU/memory combinations including nil and unparseable inputs
- Manual: apppack shell --live -a myapp -- selector entries now show web: a1b2c3 (0.5 vCPU / 1 GB); on connect a faint advisory line appears before the shell prompt