### PR TITLE
fix: allow ps resize before an app's first release

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -548,6 +548,10 @@ func (a *App) GetServices() ([]string, error) {
 
 	var services []string
 
+	if a.DeployStatus == nil {
+		return services, nil
+	}
+
 	for _, process := range a.DeployStatus.Processes {
 		services = append(services, process.Name)
 	}
@@ -555,7 +559,9 @@ func (a *App) GetServices() ([]string, error) {
 	return services, nil
 }
 
-// LoadDeployStatus will get the app.DeployStatus value from DDB
+// LoadDeployStatus will get the app.DeployStatus value from DDB.
+// If the app has never had a successful release, no DEPLOYSTATUS item
+// exists yet -- this is not an error, so a.DeployStatus is simply left nil.
 func (a *App) LoadDeployStatus() error {
 	if a.DeployStatus != nil {
 		return nil
@@ -563,6 +569,10 @@ func (a *App) LoadDeployStatus() error {
 
 	deployStatus, err := a.GetDeployStatus("")
 	if err != nil {
+		if errors.Is(err, ErrDDBItemNotFound) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/app/utils.go
+++ b/app/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -16,6 +17,10 @@ import (
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/sirupsen/logrus"
 )
+
+// ErrDDBItemNotFound indicates a DynamoDB GetItem call succeeded but found no
+// item for the given key -- as opposed to an AWS/network error.
+var ErrDDBItemNotFound = errors.New("ddb item not found")
 
 func ddbItem(cfg aws.Config, primaryID, secondaryID string) (*map[string]types.AttributeValue, error) {
 	ddbSvc := dynamodb.NewFromConfig(cfg)
@@ -39,7 +44,7 @@ func ddbItem(cfg aws.Config, primaryID, secondaryID string) (*map[string]types.A
 	}
 
 	if result.Item == nil {
-		return nil, fmt.Errorf("could not find DDB item %s %s", primaryID, secondaryID)
+		return nil, fmt.Errorf("could not find DDB item %s %s: %w", primaryID, secondaryID, ErrDDBItemNotFound)
 	}
 
 	return &result.Item, nil

--- a/app/utils_test.go
+++ b/app/utils_test.go
@@ -1,0 +1,24 @@
+package app_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/apppackio/apppack/app"
+)
+
+func TestErrDDBItemNotFoundUnwraps(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("could not find DDB item %s %s: %w", "APP#foo", "DEPLOYSTATUS", app.ErrDDBItemNotFound)
+
+	if !errors.Is(wrapped, app.ErrDDBItemNotFound) {
+		t.Error("expected errors.Is to match app.ErrDDBItemNotFound through the wrapped message")
+	}
+
+	otherErr := errors.New("some other ddb error")
+	if errors.Is(otherErr, app.ErrDDBItemNotFound) {
+		t.Error("expected an unrelated error not to match app.ErrDDBItemNotFound")
+	}
+}


### PR DESCRIPTION
## Summary
- `ps resize` (and `ps` list) crashed with `could not find DDB item ... DEPLOYSTATUS` for any app that had never had a successful release, even though `ps resize` is explicitly designed to support setting a size before the first deploy.
- Root cause is a regression from #102 ("Formatting cleanup"), which changed `psResizeCmd` from silently discarding `LoadDeployStatus()`'s error to treating it as fatal via `checkErr`. Before that commit (v4.6.7), a missing `DEPLOYSTATUS` item never surfaced, so the command fell through to the existing graceful "service does not exist" handling by accident.
- Fix: add a sentinel `ErrDDBItemNotFound`, and only treat that specific case as non-fatal in `LoadDeployStatus` (leaving `DeployStatus` nil), rather than reverting to silently discarding all errors. Real errors (auth, throttling, etc.) still fail loudly, unlike the old v4.6.7 behavior. `GetServices` gets a nil-guard it needs now that `LoadDeployStatus` can return a nil `DeployStatus` without erroring.
- No changes needed to `cmd/ps.go` — both `ps resize` and `ps` (list) already handle a nil `DeployStatus` gracefully via `FindProcess`'s existing nil-receiver check; this also fixes `ps` list's identical, longer-standing bug (predates #102).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` all clean
- [x] New unit test pinning the sentinel error's wrap/unwrap contract
- [x] Verified live against a real AWS account on a genuinely fresh app (zero prior builds): crashes on unpatched v4.7.0, works correctly with this fix
- [ ] New behavioral branches (`LoadDeployStatus`'s non-fatal path, `GetServices`'s nil-guard) aren't covered by an automated test — no DynamoDB-mocking infra exists in this repo to exercise them in isolation