### PR TITLE
selfupdate: error on oversized binary instead of silent truncation

### DIFF
--- a/selfupdate/selfupdate.go
+++ b/selfupdate/selfupdate.go
@@ -25,11 +25,13 @@ import (
 const (
 	repoOwner = "apppackio"
 	repoName  = "apppack"
-
-	// maxBinarySize is the maximum allowed size for the extracted binary (100MB).
-	// This prevents potential DoS via decompression bombs.
-	maxBinarySize = 100 * 1024 * 1024
 )
+
+// maxBinarySize is the maximum allowed size for the extracted binary (100MB).
+// This prevents potential DoS via decompression bombs. It is a var (rather
+// than a const) so tests can lower the cap without materializing a 100MB
+// fixture.
+var maxBinarySize int64 = 100 * 1024 * 1024
 
 // PlatformInfo represents the current platform for download purposes.
 type PlatformInfo struct {
@@ -260,13 +262,18 @@ func extractTarGz(archivePath, destDir string) (string, error) {
 				return "", fmt.Errorf("creating binary file: %w", err)
 			}
 
-			if _, err := io.CopyN(outFile, tr, maxBinarySize); err != nil && !errors.Is(err, io.EOF) {
-				outFile.Close()
+			// Read one byte past the cap so we can detect (rather than
+			// silently truncate) a binary that exceeds maxBinarySize.
+			n, err := io.Copy(outFile, io.LimitReader(tr, maxBinarySize+1))
+			outFile.Close()
 
+			if err != nil {
 				return "", fmt.Errorf("extracting binary: %w", err)
 			}
 
-			outFile.Close()
+			if n > maxBinarySize {
+				return "", fmt.Errorf("binary exceeds maximum allowed size (%d bytes)", maxBinarySize)
+			}
 
 			break
 		}
@@ -305,12 +312,18 @@ func extractZip(archivePath, destDir string) (string, error) {
 				return "", fmt.Errorf("creating binary file: %w", err)
 			}
 
-			_, err = io.CopyN(outFile, rc, maxBinarySize)
+			// Read one byte past the cap so we can detect (rather than
+			// silently truncate) a binary that exceeds maxBinarySize.
+			n, err := io.Copy(outFile, io.LimitReader(rc, maxBinarySize+1))
 			rc.Close()
 			outFile.Close()
 
-			if err != nil && !errors.Is(err, io.EOF) {
+			if err != nil {
 				return "", fmt.Errorf("extracting binary: %w", err)
+			}
+
+			if n > maxBinarySize {
+				return "", fmt.Errorf("binary exceeds maximum allowed size (%d bytes)", maxBinarySize)
 			}
 
 			break

--- a/selfupdate/selfupdate_test.go
+++ b/selfupdate/selfupdate_test.go
@@ -1,6 +1,10 @@
 package selfupdate
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -178,4 +182,122 @@ func TestVerifyChecksumFileNotFound(t *testing.T) {
 	err := VerifyChecksum("/nonexistent/file.txt", "somehash")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "opening file")
+}
+
+// writeTarGz builds a .tar.gz archive at path containing a single regular
+// file named "apppack" with the given contents.
+func writeTarGz(t *testing.T, path string, contents []byte) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	gzw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gzw)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "apppack",
+		Typeflag: tar.TypeReg,
+		Mode:     0o755,
+		Size:     int64(len(contents)),
+	}))
+	_, err = tw.Write(contents)
+	require.NoError(t, err)
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+}
+
+// writeZip builds a .zip archive at path containing a single file named
+// "apppack.exe" with the given contents.
+func writeZip(t *testing.T, path string, contents []byte) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("apppack.exe")
+	require.NoError(t, err)
+	_, err = w.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+}
+
+func TestExtractTarGzSuccess(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "apppack.tar.gz")
+	contents := []byte("i am the apppack binary")
+	writeTarGz(t, archivePath, contents)
+
+	binPath, err := extractTarGz(archivePath, dir)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, contents, got)
+}
+
+func TestExtractTarGzExceedsMaxSize(t *testing.T) {
+	// Shrink the cap so we don't need a 100MB fixture.
+	orig := maxBinarySize
+	maxBinarySize = 16
+	defer func() { maxBinarySize = orig }()
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "apppack.tar.gz")
+	// One byte over the cap must be rejected, not silently truncated.
+	writeTarGz(t, archivePath, bytes.Repeat([]byte("A"), int(maxBinarySize)+1))
+
+	_, err := extractTarGz(archivePath, dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+}
+
+func TestExtractTarGzAtMaxSize(t *testing.T) {
+	orig := maxBinarySize
+	maxBinarySize = 16
+	defer func() { maxBinarySize = orig }()
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "apppack.tar.gz")
+	contents := bytes.Repeat([]byte("A"), int(maxBinarySize))
+	writeTarGz(t, archivePath, contents)
+
+	binPath, err := extractTarGz(archivePath, dir)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, contents, got)
+}
+
+func TestExtractZipSuccess(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "apppack.zip")
+	contents := []byte("i am the apppack.exe binary")
+	writeZip(t, archivePath, contents)
+
+	binPath, err := extractZip(archivePath, dir)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, contents, got)
+}
+
+func TestExtractZipExceedsMaxSize(t *testing.T) {
+	orig := maxBinarySize
+	maxBinarySize = 16
+	defer func() { maxBinarySize = orig }()
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "apppack.zip")
+	writeZip(t, archivePath, bytes.Repeat([]byte("A"), int(maxBinarySize)+1))
+
+	_, err := extractZip(archivePath, dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
 }


### PR DESCRIPTION
`io.CopyN` copies exactly up to `maxBinarySize` (100MB) and returns `nil` (not `io.EOF`) when the source is >= the cap, so an oversized binary was silently truncated to exactly 100MB and only surfaced downstream as a confusing checksum mismatch.

Both `extractTarGz` and `extractZip` now use `io.Copy` with `io.LimitReader(src, maxBinarySize+1)` and error explicitly with "binary exceeds maximum allowed size" when the cap is exceeded. `maxBinarySize` is now a `var` so tests can lower the cap without a 100MB fixture.

Added extract tests (success, at-cap, over-cap) for both formats.

Closes #153