### PR TITLE
chore: suppress DeepSource huge-param check on utils.go

### DIFF
--- a/app/utils.go
+++ b/app/utils.go
@@ -22,7 +22,7 @@ import (
 // item for the given key -- as opposed to an AWS/network error.
 var ErrDDBItemNotFound = errors.New("ddb item not found")
 
-func ddbItem(cfg aws.Config, primaryID, secondaryID string) (*map[string]types.AttributeValue, error) {
+func ddbItem(cfg aws.Config, primaryID, secondaryID string) (*map[string]types.AttributeValue, error) { // skipcq: CRT-P0003
 	ddbSvc := dynamodb.NewFromConfig(cfg)
 
 	logrus.WithFields(logrus.Fields{"primaryID": primaryID, "secondaryID": secondaryID}).Debug("DynamoDB GetItem")
@@ -50,7 +50,7 @@ func ddbItem(cfg aws.Config, primaryID, secondaryID string) (*map[string]types.A
 	return &result.Item, nil
 }
 
-func SsmParameters(cfg aws.Config, path string) ([]ssmtypes.Parameter, error) {
+func SsmParameters(cfg aws.Config, path string) ([]ssmtypes.Parameter, error) { // skipcq: CRT-P0003
 	ssmSvc := ssm.NewFromConfig(cfg)
 
 	var parameters []ssmtypes.Parameter
@@ -74,7 +74,7 @@ func SsmParameters(cfg aws.Config, path string) ([]ssmtypes.Parameter, error) {
 	return parameters, nil
 }
 
-func SsmParameter(cfg aws.Config, name string) (*ssmtypes.Parameter, error) {
+func SsmParameter(cfg aws.Config, name string) (*ssmtypes.Parameter, error) { // skipcq: CRT-P0003
 	ssmSvc := ssm.NewFromConfig(cfg)
 	withDecryption := true
 	input := &ssm.GetParameterInput{
@@ -90,7 +90,7 @@ func SsmParameter(cfg aws.Config, name string) (*ssmtypes.Parameter, error) {
 	return result.Parameter, nil
 }
 
-func S3FromURL(cfg aws.Config, logURL string) (*strings.Builder, error) {
+func S3FromURL(cfg aws.Config, logURL string) (*strings.Builder, error) { // skipcq: CRT-P0003
 	s3Svc := s3.NewFromConfig(cfg)
 	parts := strings.Split(strings.TrimPrefix(logURL, "s3://"), "/")
 	bucket := parts[0]


### PR DESCRIPTION
## Why

DeepSource flagged 4 "huge param" issues (CRT-P0003, Major/Performance) on PR #156, all on `app/utils.go`:

- `ddbItem`
- `SsmParameters`
- `SsmParameter`
- `S3FromURL`

Each takes `cfg aws.Config` by value (696 bytes) and DeepSource suggests passing a pointer instead to avoid the copy.

## Why this is being suppressed, not fixed

`aws.Config` passed by value is the established convention across this codebase -- ~70 other functions in `cmd/`, `stacks/`, `ddb/`, `bridge/` do the same thing, and it matches the AWS SDK v2's own API (`dynamodb.NewFromConfig`, `ssm.NewFromConfig`, `s3.NewFromConfig`, etc. all take `aws.Config` by value too).

Each of these 4 functions is called once per CLI invocation, and immediately makes a network round trip to AWS. Copying 696 bytes is negligible next to that -- and switching just these 4 to a pointer would be inconsistent with every other call site for no measurable benefit.

Suppressed with `// skipcq: CRT-P0003`, the same mechanism already used elsewhere in this repo (`stacks/app_pipeline.go`'s `skipcq: GO-R1005`) to silence an unrelated DeepSource finding.

## What this doesn't change

No behavior change -- purely a comment addition on 4 function signatures.
