### PR TITLE
Friendlier handling of incomplete local AWS credentials

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1291,7 +1291,7 @@ func Init(name string, awsCredentials bool, sessionDuration int) (*App, error) {
 	if awsCredentials {
 		cfg, err := config.LoadDefaultConfig(context.Background())
 		if err != nil {
-			return nil, err
+			return nil, auth.FriendlyAWSConfigError(err)
 		}
 		app.Session = cfg
 		app.AWS = apppackaws.New(cfg)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/apppackio/apppack/state"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -12,6 +13,38 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/sirupsen/logrus"
 )
+
+// ignoreSharedConfigFiles disables loading of the local AWS shared config and
+// credentials files (~/.aws/config, ~/.aws/credentials). AppPack's OAuth flow
+// injects its own credentials, so those files are never needed here. Without
+// this, a partially-configured [default] profile on the user's machine makes
+// every non-`auth` command fail with an opaque SDK error.
+func ignoreSharedConfigFiles() config.LoadOptionsFunc {
+	return func(o *config.LoadOptions) error {
+		o.SharedConfigFiles = []string{}
+		o.SharedCredentialsFiles = []string{}
+		return nil
+	}
+}
+
+// FriendlyAWSConfigError adds a hint to errors returned when loading the local
+// AWS configuration (the `--aws-credentials` flow, which intentionally reads
+// the user's ~/.aws files). The raw SDK "partial credentials" error is opaque;
+// this points the user at the real, machine-local cause.
+func FriendlyAWSConfigError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "partial credentials") {
+		return fmt.Errorf(
+			"%w: your local AWS credentials appear to be incomplete — "+
+				"check for a partial [default] profile in ~/.aws/credentials or ~/.aws/config, "+
+				"or stray AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY environment variables",
+			err,
+		)
+	}
+	return err
+}
 
 const (
 	deviceCodeURL = "https://auth.apppack.io/oauth/device/code"
@@ -53,6 +86,7 @@ func AppAWSSession(appName string, sessionDuration int) (aws.Config, *AppRole, e
 			*creds.SessionToken,
 		)),
 		config.WithRegion(appRole.Region),
+		ignoreSharedConfigFiles(),
 	)
 	if err != nil {
 		return aws.Config{}, nil, err
@@ -90,6 +124,7 @@ func AdminAWSSession(idOrAlias string, sessionDuration int, region string) (aws.
 			*creds.SessionToken,
 		)),
 		config.WithRegion(region),
+		ignoreSharedConfigFiles(),
 	)
 	if err != nil {
 		return aws.Config{}, nil, err

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFriendlyAWSConfigError(t *testing.T) {
+	t.Run("nil error stays nil", func(t *testing.T) {
+		if err := FriendlyAWSConfigError(nil); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("partial credentials error gets a hint", func(t *testing.T) {
+		raw := errors.New("error fetching config from profile, default, Error using profile: \n 2, partial credentials found for profile default")
+		got := FriendlyAWSConfigError(raw)
+		if got == nil {
+			t.Fatal("expected wrapped error, got nil")
+		}
+		if !strings.Contains(got.Error(), "local AWS credentials appear to be incomplete") {
+			t.Errorf("expected friendly hint, got: %v", got)
+		}
+		if !errors.Is(got, raw) {
+			t.Error("expected wrapped error to preserve the original via errors.Is")
+		}
+	})
+
+	t.Run("unrelated error is passed through unchanged", func(t *testing.T) {
+		raw := errors.New("some other failure")
+		got := FriendlyAWSConfigError(raw)
+		if !errors.Is(got, raw) || got.Error() != raw.Error() {
+			t.Errorf("expected passthrough, got: %v", got)
+		}
+	})
+}

--- a/auth/tokens.go
+++ b/auth/tokens.go
@@ -233,6 +233,7 @@ func (t *Tokens) GetCredentials(role Role, duration int) (*types.Credentials, er
 
 	cfg, err := config.LoadDefaultConfig(context.Background(),
 		config.WithRegion("us-east-1"), // STS is a global service, use us-east-1 as default
+		ignoreSharedConfigFiles(),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/access.go
+++ b/cmd/access.go
@@ -86,12 +86,13 @@ func adminSession(sessionDuration int) (aws.Config, error) {
 	if UseAWSCredentials {
 		ctx := context.Background()
 		if region != "" {
-			return config.LoadDefaultConfig(ctx, config.WithRegion(region))
+			cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+			return cfg, auth.FriendlyAWSConfigError(err)
 		}
 
 		cfg, err := config.LoadDefaultConfig(ctx)
 		if err != nil {
-			return aws.Config{}, err
+			return aws.Config{}, auth.FriendlyAWSConfigError(err)
 		}
 
 		if cfg.Region == "" {


### PR DESCRIPTION
Closes #155.

## Problem
With a partially-configured `default` profile (or stray `AWS_*` env vars), every command except `apppack auth` failed with the raw SDK error:

```
error fetching config from profile, default, Error using profile:
 2, partial credentials found for profile default
```

`auth` worked because it's a pure OAuth flow; everything else calls `LoadDefaultConfig`, which eagerly loads and validates the local `~/.aws` files before doing any real work.

## Key finding
I reproduced this and confirmed the SDK trips on a partial `[default]` profile **even when static credentials are supplied via `WithCredentialsProvider`** — so just wrapping the error (the original proposal) wouldn't make OAuth-authenticated commands work; it would only reword the failure. The maintainer's suggestion on the issue (bypass loading default config for the OAuth flow) is the real fix.

## Fix — two treatments matching the two kinds of call site
1. **OAuth paths** (`AppAWSSession`, `AdminAWSSession`, `GetCredentials`) — these inject OAuth-derived static credentials / use web-identity federation and never need the local files. New `ignoreSharedConfigFiles()` load option disables shared config/credentials file loading. This *eliminates* the "auth works but nothing else does" failure.
2. **`--aws-credentials` paths** (`app.Init`, `cmd/access.adminSession`) — these read local config by design, so bypassing isn't an option. New `auth.FriendlyAWSConfigError()` detects the "partial credentials" signature and appends a hint at the real, machine-local cause (original error preserved via `%w`).

## Verification
- Reproduced the failure against a partial `[default]` profile and confirmed the shared-file bypass makes the static-cred path succeed.
- `auth.FriendlyAWSConfigError` unit-tested (nil passthrough, partial-cred hint, `errors.Is` unwrap, unrelated passthrough).
- `go build ./...`, `go test ./auth/... ./app/... ./cmd/...`, and `golangci-lint run ./auth/...` clean (only pre-existing errcheck findings remain).