### PR TITLE
feat: add ps restart command with --force flag

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1178,6 +1178,83 @@ func (a *App) ResizeProcess(processType string, cpu, memory int) error {
 	return a.SetScaleParameter(processType, nil, nil, &cpu, &memory)
 }
 
+// RestartProcess restarts the ECS service or tasks for the given processType.
+// When force is false, it triggers a graceful rolling restart via UpdateService with
+// ForceNewDeployment. When force is true, it stops all running tasks matching the
+// processType tag, causing ECS to relaunch them.
+func (a *App) RestartProcess(processType string, force bool) error {
+	if err := a.LoadSettings(); err != nil {
+		return fmt.Errorf("loading settings: %w", err)
+	}
+
+	ecsSvc := ecs.NewFromConfig(a.Session)
+
+	if !force {
+		serviceName := a.ServiceName(processType)
+		logrus.WithFields(logrus.Fields{"service": serviceName}).Debug("triggering rolling restart")
+
+		_, err := ecsSvc.UpdateService(context.Background(), &ecs.UpdateServiceInput{
+			Cluster:            &a.Settings.Cluster.ARN,
+			Service:            aws.String(serviceName),
+			ForceNewDeployment: true,
+		})
+		if err != nil {
+			return fmt.Errorf("updating service %s: %w", serviceName, err)
+		}
+
+		return nil
+	}
+
+	// Force restart: stop all matching tasks so ECS relaunches them.
+	tasks, err := a.DescribeTasks()
+	if err != nil {
+		return fmt.Errorf("describing tasks: %w", err)
+	}
+
+	var matchingARNs []string
+	for i := range tasks {
+		tagVal, tagErr := getTagFromTask(&tasks[i], "apppack:processType")
+		if tagErr != nil {
+			continue
+		}
+
+		if tagVal == processType {
+			matchingARNs = append(matchingARNs, *tasks[i].TaskArn)
+		}
+	}
+
+	if len(matchingARNs) == 0 {
+		return fmt.Errorf("no running tasks found for process type %q", processType)
+	}
+
+	for _, taskARN := range matchingARNs {
+		arn := taskARN // capture loop variable
+		logrus.WithFields(logrus.Fields{"task": arn}).Debug("stopping task")
+
+		_, err := ecsSvc.StopTask(context.Background(), &ecs.StopTaskInput{
+			Cluster: &a.Settings.Cluster.ARN,
+			Task:    &arn,
+			Reason:  aws.String("apppack ps restart --force"),
+		})
+		if err != nil {
+			return fmt.Errorf("stopping task %s: %w", arn, err)
+		}
+	}
+
+	return nil
+}
+
+// getTagFromTask returns the value of the named tag on an ECS task.
+func getTagFromTask(task *ecstypes.Task, key string) (string, error) {
+	for _, t := range task.Tags {
+		if t.Key != nil && *t.Key == key && t.Value != nil {
+			return *t.Value, nil
+		}
+	}
+
+	return "", fmt.Errorf("tag %s not found on task", key)
+}
+
 func (a *App) ScaleProcess(processType string, minProcessCount, maxProcessCount int) error {
 	return a.SetScaleParameter(processType, &minProcessCount, &maxProcessCount, nil, nil)
 }

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -309,6 +309,37 @@ apppack -a my-app ps scale worker 1-4  # autoscale worker service from 1 to 4 pr
 	},
 }
 
+// psRestartCmd represents the restart command
+var psRestartCmd = &cobra.Command{
+	Use:   "restart <process_type>",
+	Short: "restart the process for a given type",
+	Long: `Restart the ECS service for a given process type.
+
+By default, a graceful rolling restart is performed (ForceNewDeployment). Use
+--force to immediately stop all running containers for the process type; ECS
+will relaunch them automatically.`,
+	Example: `apppack -a my-app ps restart web          # graceful rolling restart
+apppack -a my-app ps restart web --force  # kill running containers (forced restart)`,
+	DisableFlagsInUseLine: true,
+	Args:                  cobra.ExactArgs(1),
+	Run: func(_ *cobra.Command, args []string) {
+		processType := args[0]
+		ui.StartSpinner()
+		a, err := app.Init(AppName, UseAWSCredentials, SessionDurationSeconds)
+		checkErr(err)
+		if a.Pipeline && !a.IsReviewApp() {
+			checkErr(errors.New("pipelines don't directly run processes"))
+		}
+		checkErr(a.RestartProcess(processType, psRestartForce))
+		ui.Spinner.Stop()
+		if psRestartForce {
+			printSuccess(fmt.Sprintf("forcefully restarted %s (running containers stopped; ECS will relaunch them)", processType))
+		} else {
+			printSuccess(fmt.Sprintf("triggered rolling restart of %s", processType))
+		}
+	},
+}
+
 // execCmd represents the exec command
 var psExecCmd = &cobra.Command{
 	Use:                   "exec -- <command>",
@@ -325,8 +356,9 @@ var psExecCmd = &cobra.Command{
 }
 
 var (
-	scaleCPU    float64
-	scaleMemory string
+	scaleCPU       float64
+	scaleMemory    string
+	psRestartForce bool
 )
 
 func init() {
@@ -342,6 +374,10 @@ func init() {
 	_ = psResizeCmd.MarkFlagRequired("memory")
 
 	psCmd.AddCommand(psScaleCmd)
+
+	psCmd.AddCommand(psRestartCmd)
+	psRestartCmd.Flags().BoolVar(&psRestartForce, "force", false, "forcefully restart by killing running containers instead of a graceful rolling restart")
+
 	psCmd.AddCommand(psExecCmd)
 	psExecCmd.PersistentFlags().BoolVarP(&shellRoot, "root", "r", false, "open shell as root user")
 	psExecCmd.PersistentFlags().BoolVarP(&shellLive, "live", "l", false, "connect to a live process")

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apppackio/apppack/app"
 	"github.com/apppackio/apppack/ui"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/smithy-go"
 	"github.com/dustin/go-humanize"
 	"github.com/logrusorgru/aurora"
 	"github.com/sirupsen/logrus"
@@ -330,8 +331,18 @@ apppack -a my-app ps restart web --force  # kill running containers (forced rest
 		if a.Pipeline && !a.IsReviewApp() {
 			checkErr(errors.New("pipelines don't directly run processes"))
 		}
-		checkErr(a.RestartProcess(processType, psRestartForce))
+		err = a.RestartProcess(processType, psRestartForce)
 		ui.Spinner.Stop()
+		if err != nil {
+			// Older app stacks (created before the WebOperatorRole gained
+			// ecs:UpdateService/ecs:StopTask) will get AccessDenied. Point the
+			// user at the upgrade that grants the required permissions.
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException" {
+				printWarning(fmt.Sprintf("access denied -- the app stack may need to be upgraded: `apppack upgrade app %s`", AppName))
+			}
+			checkErr(err)
+		}
 		if psRestartForce {
 			printSuccess(fmt.Sprintf("forcefully restarted %s (running containers stopped; ECS will relaunch them)", processType))
 		} else {


### PR DESCRIPTION
## Summary

- Adds `apppack ps restart <process_type>` CLI command (closes #39)
- Graceful path (default): calls ECS `UpdateService` with `ForceNewDeployment: true` for a zero-downtime rolling restart
- Forced path (`--force`): stops all running containers matching the `apppack:processType` tag via `StopTask`; ECS relaunches them automatically
- Pipelines without a review app are blocked (same guard as `ps scale`)

## Implementation

- `app/app.go`: new `RestartProcess(processType string, force bool) error` method + unexported `getTagFromTask` helper
- `cmd/ps.go`: new `psRestartCmd` registered under `psCmd`, with `--force` bool flag

## Notes

The required IAM permissions (ecs:UpdateService, ecs:StopTask, ecs:ListTasks, ecs:DescribeTasks scoped by ecs:cluster) were already added to WebOperatorRole in apppack-backend commit 45261d2 - this is CLI-only work.

Closes #39
