### PR TITLE
docs: catch up unreleased changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `version check` command to check if a newer CLI version is available.
 * `version update` command to download and install the latest CLI version from GitHub releases.
+* `shell --live`/`ps exec --live` now show each process's size (CPU/memory) in the selector, and print an advisory naming the process and its size after connecting.
+
+### Fixed
+
+* `ps resize` no longer fails on apps that have never had a successful release.
+* `shell` now only uses a login shell (`bash -l`) for buildpack apps, avoiding cases where it clobbered a `PATH` set by a Dockerfile-based app's image.
+* `selfupdate` now errors clearly when a downloaded binary exceeds the size limit, instead of silently truncating it to a confusing checksum mismatch.
+* Commands other than `auth` no longer fail with a raw SDK error when the local `~/.aws` config has a partial/incomplete `default` profile.
 
 ## [4.7.0] - 2026-06-24
 


### PR DESCRIPTION
## Summary
Adds the missing Unreleased entries for everything merged into `main` since the `v4.7.0` tag that wasn't yet reflected in the changelog:
- shell/ps live-size display in the selector + connect advisory
- `ps resize` before-first-deploy fix
- buildpack-only `bash -l` fix
- selfupdate oversized-binary error
- friendlier handling of incomplete local AWS credentials

Left out the DeepSource lint suppression and the survey-abstraction cleanup, since neither changes user-visible behavior.