### PR TITLE
Skip interactive prompts for database flags that are explicitly set

### DIFF
--- a/stacks/database.go
+++ b/stacks/database.go
@@ -75,6 +75,21 @@ func standardEngineName(engine *string) (string, error) {
 	return "", errors.New("unrecognized databae engine. valid options are 'mysql' or 'postgres'")
 }
 
+var validDatabaseEngines = []string{"mysql", "postgres", "aurora-mysql", "aurora-postgresql"}
+
+// validateDatabaseEngine ensures an engine value passed via the --engine flag is
+// one AppPack supports. The full engine name (including the aurora- variants) is
+// accepted so that flags fully bypass the interactive engine/aurora prompts.
+func validateDatabaseEngine(engine string) error {
+	for _, e := range validDatabaseEngines {
+		if engine == e {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid engine %q -- must be one of %s", engine, strings.Join(validDatabaseEngines, ", "))
+}
+
 func getLatestRdsVersion(cfg aws.Config, engine *string) (string, error) {
 	rdsSvc := rds.NewFromConfig(cfg)
 
@@ -180,6 +195,14 @@ var DefaultDatabaseStackParameters = DatabaseStackParameters{
 type DatabaseStack struct {
 	Stack      *types.Stack
 	Parameters *DatabaseStackParameters
+	// setFlags records which flags were explicitly provided on the command line
+	// so AskQuestions can skip the corresponding interactive prompt.
+	setFlags map[string]bool
+}
+
+// flagWasSet reports whether the named flag was explicitly provided by the user.
+func (a *DatabaseStack) flagWasSet(name string) bool {
+	return a.setFlags[name]
 }
 
 func (a *DatabaseStack) GetParameters() Parameters {
@@ -271,6 +294,11 @@ func (a *DatabaseStack) ClusterName() string {
 }
 
 func (a *DatabaseStack) UpdateFromFlags(flags *pflag.FlagSet) error {
+	a.setFlags = map[string]bool{}
+	flags.Visit(func(flag *pflag.Flag) {
+		a.setFlags[flag.Name] = true
+	})
+
 	return ui.FlagsToStruct(a.Parameters, flags)
 }
 
@@ -278,41 +306,52 @@ func (a *DatabaseStack) AskQuestions(cfg aws.Config) error {
 	var err error
 
 	if a.Stack == nil {
-		err = AskForCluster(
-			cfg,
-			"Which cluster should this Database be installed in?",
-			"A cluster represents an isolated network and its associated resources (Apps, Database, Redis, etc.).",
-			&a.Parameters.ClusterStackName,
-		)
-		if err != nil {
-			return err
+		if !a.flagWasSet("cluster") {
+			err = AskForCluster(
+				cfg,
+				"Which cluster should this Database be installed in?",
+				"A cluster represents an isolated network and its associated resources (Apps, Database, Redis, etc.).",
+				&a.Parameters.ClusterStackName,
+			)
+			if err != nil {
+				return err
+			}
 		}
 
-		// Engine prompt
-		engineForm, enginePtr := DatabaseEngineForm(a.Parameters.Engine)
-		if err = engineForm.Run(); err != nil {
-			return err
-		}
-		a.Parameters.Engine = *enginePtr
+		// The --engine flag accepts the fully-qualified engine name (including the
+		// aurora- variants), so if it was provided we skip both the engine and
+		// aurora prompts entirely.
+		if a.flagWasSet("engine") {
+			if err = validateDatabaseEngine(a.Parameters.Engine); err != nil {
+				return err
+			}
+		} else {
+			// Engine prompt
+			engineForm, enginePtr := DatabaseEngineForm(a.Parameters.Engine)
+			if err = engineForm.Run(); err != nil {
+				return err
+			}
+			a.Parameters.Engine = *enginePtr
 
-		// Aurora prompt
-		auroraForm, auroraPtr := DatabaseAuroraForm(false)
-		if err = auroraForm.Run(); err != nil {
-			return err
+			// Aurora prompt
+			auroraForm, auroraPtr := DatabaseAuroraForm(false)
+			if err = auroraForm.Run(); err != nil {
+				return err
+			}
+			aurora := ui.YesNoToBool(*auroraPtr)
+
+			if aurora {
+				a.Parameters.Engine, err = auroraEngineName(&a.Parameters.Engine)
+			} else {
+				a.Parameters.Engine, err = standardEngineName(&a.Parameters.Engine)
+			}
+
+			if err != nil {
+				return err
+			}
 		}
-		aurora := ui.YesNoToBool(*auroraPtr)
 
 		ui.StartSpinner()
-
-		if aurora {
-			a.Parameters.Engine, err = auroraEngineName(&a.Parameters.Engine)
-		} else {
-			a.Parameters.Engine, err = standardEngineName(&a.Parameters.Engine)
-		}
-
-		if err != nil {
-			return err
-		}
 
 		a.Parameters.Version, err = getLatestRdsVersion(cfg, &a.Parameters.Engine)
 		if err != nil {
@@ -320,30 +359,34 @@ func (a *DatabaseStack) AskQuestions(cfg aws.Config) error {
 		}
 	}
 
-	ui.StartSpinner()
-	ui.Spinner.Suffix = " retrieving instance classes for " + a.Parameters.Engine
-
-	instanceClasses, err := listRDSInstanceClasses(cfg, &a.Parameters.Engine, &a.Parameters.Version)
-	if err != nil {
-		return err
-	}
-
-	ui.Spinner.Stop()
-	ui.Spinner.Suffix = ""
-
 	// Instance class prompt
-	instanceClassForm, instanceClassPtr := DatabaseInstanceClassForm(instanceClasses, a.Parameters.InstanceClass)
-	if err = instanceClassForm.Run(); err != nil {
-		return err
+	if !a.flagWasSet("instance-class") {
+		ui.StartSpinner()
+		ui.Spinner.Suffix = " retrieving instance classes for " + a.Parameters.Engine
+
+		instanceClasses, err := listRDSInstanceClasses(cfg, &a.Parameters.Engine, &a.Parameters.Version)
+		if err != nil {
+			return err
+		}
+
+		ui.Spinner.Stop()
+		ui.Spinner.Suffix = ""
+
+		instanceClassForm, instanceClassPtr := DatabaseInstanceClassForm(instanceClasses, a.Parameters.InstanceClass)
+		if err = instanceClassForm.Run(); err != nil {
+			return err
+		}
+		a.Parameters.InstanceClass = *instanceClassPtr
 	}
-	a.Parameters.InstanceClass = *instanceClassPtr
 
 	// Multi-AZ prompt
-	multiAZForm, multiAZPtr := DatabaseMultiAZForm(a.Parameters.MultiAZ)
-	if err = multiAZForm.Run(); err != nil {
-		return err
+	if !a.flagWasSet("multi-az") {
+		multiAZForm, multiAZPtr := DatabaseMultiAZForm(a.Parameters.MultiAZ)
+		if err = multiAZForm.Run(); err != nil {
+			return err
+		}
+		a.Parameters.MultiAZ = ui.YesNoToBool(*multiAZPtr)
 	}
-	a.Parameters.MultiAZ = ui.YesNoToBool(*multiAZPtr)
 
 	return nil
 }

--- a/stacks/database_test.go
+++ b/stacks/database_test.go
@@ -4,7 +4,90 @@ import (
 	"testing"
 
 	"github.com/apppackio/apppack/ui/uitest"
+	"github.com/spf13/pflag"
 )
+
+func TestValidateDatabaseEngine(t *testing.T) {
+	valid := []string{"mysql", "postgres", "aurora-mysql", "aurora-postgresql"}
+	for _, e := range valid {
+		if err := validateDatabaseEngine(e); err != nil {
+			t.Errorf("expected %q to be valid, got error: %v", e, err)
+		}
+	}
+
+	invalid := []string{"", "sqlite", "aurora", "Postgres", "mariadb"}
+	for _, e := range invalid {
+		if err := validateDatabaseEngine(e); err == nil {
+			t.Errorf("expected %q to be invalid, got no error", e)
+		}
+	}
+}
+
+// newDatabaseFlagSet mirrors the flags registered on createDatabaseCmd so we can
+// exercise UpdateFromFlags without pulling in the cmd package.
+func newDatabaseFlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("database", pflag.ContinueOnError)
+	flags.String("cluster", "apppack", "cluster name")
+	flags.StringP("instance-class", "i", DefaultDatabaseStackParameters.InstanceClass, "instance class")
+	flags.StringP("engine", "e", DefaultDatabaseStackParameters.Engine, "engine")
+	flags.Bool("multi-az", DefaultDatabaseStackParameters.MultiAZ, "enable multi-AZ")
+	flags.Int("allocated-storage", DefaultDatabaseStackParameters.AllocatedStorage, "allocated storage")
+	flags.Int("max-allocated-storage", DefaultDatabaseStackParameters.MaxAllocatedStorage, "max allocated storage")
+
+	return flags
+}
+
+func TestUpdateFromFlagsRecordsSetFlags(t *testing.T) {
+	flags := newDatabaseFlagSet()
+	if err := flags.Parse([]string{"--engine", "aurora-postgresql", "--multi-az"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	params := DefaultDatabaseStackParameters
+	stack := DatabaseStack{Parameters: &params}
+	if err := stack.UpdateFromFlags(flags); err != nil {
+		t.Fatalf("UpdateFromFlags returned error: %v", err)
+	}
+
+	if !stack.flagWasSet("engine") {
+		t.Error("expected engine flag to be recorded as set")
+	}
+	if !stack.flagWasSet("multi-az") {
+		t.Error("expected multi-az flag to be recorded as set")
+	}
+	if stack.flagWasSet("cluster") {
+		t.Error("expected cluster flag to be recorded as not set")
+	}
+	if stack.flagWasSet("instance-class") {
+		t.Error("expected instance-class flag to be recorded as not set")
+	}
+
+	if params.Engine != "aurora-postgresql" {
+		t.Errorf("expected engine 'aurora-postgresql', got %q", params.Engine)
+	}
+	if !params.MultiAZ {
+		t.Error("expected multi-az to be true")
+	}
+}
+
+func TestUpdateFromFlagsNoFlagsSet(t *testing.T) {
+	flags := newDatabaseFlagSet()
+	if err := flags.Parse([]string{}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	params := DefaultDatabaseStackParameters
+	stack := DatabaseStack{Parameters: &params}
+	if err := stack.UpdateFromFlags(flags); err != nil {
+		t.Fatalf("UpdateFromFlags returned error: %v", err)
+	}
+
+	for _, name := range []string{"cluster", "engine", "instance-class", "multi-az"} {
+		if stack.flagWasSet(name) {
+			t.Errorf("expected %q to be recorded as not set", name)
+		}
+	}
+}
 
 func TestDatabaseEngineForm_DefaultPostgres(t *testing.T) {
 	form, selectedPtr := DatabaseEngineForm("postgres")


### PR DESCRIPTION
## Problem

`apppack create database` ignored flags like `--engine`. Even when a flag was provided, `AskQuestions` unconditionally re-prompted for cluster, engine, aurora, instance-class, and multi-az — the flag value was only used as the prompt default, so users still had to pick from a dropdown.

Fixes #85.

## Change

- `UpdateFromFlags` now records which flags the user explicitly set (via `flags.Visit`).
- `AskQuestions` skips the prompt for any flag that was set.
- `--engine` accepts the fully-qualified engine name (`mysql`, `postgres`, `aurora-mysql`, `aurora-postgresql`) and bypasses both the engine and aurora prompts. The value is validated so a typo fails fast instead of silently.
- When `--instance-class` is provided, the RDS `DescribeOrderableDBInstanceOptions` API call is skipped entirely (no prompt, no lookup).

Flags left unset still prompt interactively exactly as before. `--non-interactive` is unaffected.

## Notes

The same 'flag ignored' pattern applies to other `create` subcommands (ipmb noted `--cluster`); this PR fixes the database command. Happy to follow up with the same treatment elsewhere if we like the approach.