### PR TITLE
fix: remove -j shorthand from --json, keep it on db load --jobs

### DIFF
--- a/cmd/json_test.go
+++ b/cmd/json_test.go
@@ -257,8 +257,9 @@ func TestRootJSONPersistentFlag(t *testing.T) {
 		return
 	}
 
-	if flag.Shorthand != "j" {
-		t.Errorf("expected shorthand -j, got %q", flag.Shorthand)
+	// -j is reserved for `db load`'s --jobs flag, which predates --json.
+	if flag.Shorthand != "" {
+		t.Errorf("expected no shorthand, got %q", flag.Shorthand)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,7 +118,7 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging")
-	rootCmd.PersistentFlags().BoolVarP(&AsJSON, "json", "j", false, "output as JSON")
+	rootCmd.PersistentFlags().BoolVar(&AsJSON, "json", false, "output as JSON")
 }
 
 func checkErr(err error) {


### PR DESCRIPTION
## Bug

db load was broken on every invocation, for every app:

```
apppack -a <app> db load pruned.dump
unable to redefine 'j' shorthand in "load" flagset: it's already used for "jobs" flag
✖ Something went wrong. Please retry.
```

## Root cause

Two flags claimed shorthand -j: db load's --jobs (local flag, cmd/db.go) and root's --json (persistent flag, cmd/root.go, inherited by every command). Cobra doesn't detect this at flag registration time, since the two are registered on separate FlagSets. The collision only surfaces when Cobra merges a command's local flags with its inherited persistent flags, which happens the moment db load actually runs.

Timeline:

- 2022-03-10, commit 3d9fb8d: introduces --jobs/-j on db load
- 2026-05-01, commit 1c7b937 (PR #137): introduces --json/-j on root, inherited everywhere

--jobs -j predates --json -j by four years. PR #137 added a root level shorthand without checking it against existing subcommand flags.

## Fix

Removed the shorthand from the newer, broader flag (--json) rather than the older, narrower one (--jobs), so db load -j <n> keeps working as it always did.

- cmd/root.go: --json loses its -j shorthand
- cmd/json_test.go: TestRootJSONPersistentFlag updated accordingly

Full writeup with commit-level evidence: see the research doc linked below (not part of this repo).

## Follow-up not included here

A test scoped to --json having no shorthand only pins this fix. A generalizable regression test would walk the full command tree and call .Flags() on each command, since that's the actual merge step that panics on collision. Not added in this PR.
