### PR TITLE
fix: restore -j shorthand on config list --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* `config list -j` works again. `-j` was a shorthand for `--json` on `config list` before 4.7.0 promoted `--json` to a global flag, and removing the global shorthand in 4.8.2 took `config list -j` with it. The shorthand is registered on `config list` again; `--json` continues to work everywhere.
+
 ## [4.8.2] - 2026-08-10
 
 ### Fixed

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -242,6 +242,12 @@ func init() {
 	configCmd.AddCommand(setCmd)
 	configCmd.AddCommand(unsetCmd)
 	configCmd.AddCommand(configListCmd)
+	// `config list` carried its own --json/-j long before --json was promoted to a
+	// root persistent flag, so re-register it locally to keep `-j` working here.
+	// The shorthand can't live on the root flag: `db load` already owns -j for
+	// --jobs, and the two collide the moment cobra merges the flag sets.
+	// Same variable as the root flag, so `--json` behaves identically either way.
+	configListCmd.Flags().BoolVarP(&AsJSON, "json", "j", false, "output as JSON")
 	configCmd.AddCommand(configExportCmd)
 	configExportCmd.Flags().BoolVar(&includeManagedVars,
 		"all",

--- a/cmd/json_test.go
+++ b/cmd/json_test.go
@@ -263,6 +263,23 @@ func TestRootJSONPersistentFlag(t *testing.T) {
 	}
 }
 
+// TestConfigListJSONShorthand verifies `config list -j` still works. The
+// shorthand lived on this command before --json was promoted to a root
+// persistent flag, so it has to stay registered locally -- it can't move to
+// the root flag, which would collide with `db load --jobs`.
+func TestConfigListJSONShorthand(t *testing.T) {
+	t.Parallel()
+
+	flag := configListCmd.Flags().Lookup("json")
+	if flag == nil {
+		t.Fatal("expected --json flag on configListCmd, not found")
+	}
+
+	if flag.Shorthand != "j" {
+		t.Errorf("expected -j shorthand on `config list --json`, got %q", flag.Shorthand)
+	}
+}
+
 // captureStdout redirects os.Stdout to a pipe, runs fn, then restores stdout
 // and returns what was written.
 func captureStdout(t *testing.T, fn func()) string {


### PR DESCRIPTION
Found while auditing #166 for further fallout. This is a second, still-live casualty of the same `-j` shorthand churn.

## The regression

```
$ apppack config list -j -a myapp
Error: unknown shorthand flag: 'j' in -j
```

`config list` has owned `--json`/`-j` since long before the global flag existed. The timeline:

| Version | State of `config list -j` |
|---|---|
| < 4.7.0 | works — local `-j` on `config list` |
| 4.7.0 (#137) | works — local registration deleted, but root `--json` picked up `-j` |
| 4.8.2 (#166) | **broken** — root shorthand removed to unbreak `db load` |

#137 deleted `configListCmd.Flags().BoolVarP(&AsJSON, "json", "j", ...)` and leaned on the new root shorthand to cover it. #166 then had to drop that root shorthand, correctly, because `db load --jobs` owns `-j`. Nothing was left holding it for `config list`.

## The fix

Re-register the shorthand locally on `config list`, which is where it lived originally. It can't go back on the root flag — that's the exact collision #166 fixed.

Both now work:

```
$ apppack config list -j -a myapp     # --json
$ apppack db load -j 4 dump.sql       # --jobs
```

`config list --help` still shows a single `-j, --json` entry; the local flag is bound to the same `AsJSON` variable as the root flag, so `--json` behaves identically whichever registration serves it.

## Also worth knowing

The 4.8.2 changelog says "`db load -j <n>` is unchanged" but didn't mention `config list -j` breaking. Added an Unreleased entry saying so plainly.

Refs #166, #137
