### PR TITLE
ci: gate go vet and formatting, fix existing fmt drift

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -16,3 +16,24 @@ jobs:
           go-version: "1.25"
       - name: Test
         run: go test ./... -v
+
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.25"
+      - name: Vet
+        run: go vet ./...
+      # Same tool and subcommand as `make fmt`, so a clean local run is a
+      # clean CI run. golangci-lint-action can't be used here: it only ever
+      # invokes `golangci-lint run`, with no way to select `fmt`.
+      # Deliberately not `golangci-lint run` -- that still reports ~29
+      # pre-existing errcheck findings and would land red.
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
+      - name: Format
+        run: golangci-lint fmt --diff

--- a/stacks/app_pipeline.go
+++ b/stacks/app_pipeline.go
@@ -49,12 +49,12 @@ type AppStackParameters struct {
 	DatabaseStackName    string `flag:"addon-database-name;fmtString:apppack-database-%s"`
 	RedisAddonEnabled    bool   `flag:"addon-redis" cfnignore:"-"`
 	RedisStackName       string `flag:"addon-redis-name;fmtString:apppack-redis-%s"`
-	SQSQueueEnabled                    bool   `flag:"addon-sqs"`
-	RepositoryType                     string
-	Fargate                            bool     `flag:"ec2;negate"`
-	AllowedUsers                       []string `flag:"users"`
-	BuildWebhook                       bool     `flag:"disable-build-webhook;negate"`
-	CustomTaskPolicyARN                string   `cfnparam:"CustomTaskPolicyArn"`
+	SQSQueueEnabled      bool   `flag:"addon-sqs"`
+	RepositoryType       string
+	Fargate              bool     `flag:"ec2;negate"`
+	AllowedUsers         []string `flag:"users"`
+	BuildWebhook         bool     `flag:"disable-build-webhook;negate"`
+	CustomTaskPolicyARN  string   `cfnparam:"CustomTaskPolicyArn"`
 }
 
 var DefaultAppStackParameters = AppStackParameters{

--- a/stacks/app_pipeline_test.go
+++ b/stacks/app_pipeline_test.go
@@ -560,10 +560,10 @@ func TestSelectDatabaseStack(t *testing.T) {
 	t.Helper()
 
 	tests := []struct {
-		name        string
-		databases   []string
-		wantStack   string
-		wantErrSub  string // non-empty: error must contain this substring
+		name       string
+		databases  []string
+		wantStack  string
+		wantErrSub string // non-empty: error must contain this substring
 	}{
 		{
 			name:       "zero databases → error with create instruction",
@@ -571,14 +571,14 @@ func TestSelectDatabaseStack(t *testing.T) {
 			wantErrSub: "apppack create database",
 		},
 		{
-			name:       "single database without engine",
-			databases:  []string{"mydb"},
-			wantStack:  "apppack-database-mydb",
+			name:      "single database without engine",
+			databases: []string{"mydb"},
+			wantStack: "apppack-database-mydb",
 		},
 		{
-			name:       "single database with engine suffix",
-			databases:  []string{"mydb (postgres)"},
-			wantStack:  "apppack-database-mydb",
+			name:      "single database with engine suffix",
+			databases: []string{"mydb (postgres)"},
+			wantStack: "apppack-database-mydb",
 		},
 		{
 			name:       "multiple databases → error listing names and flag hint",


### PR DESCRIPTION
Fallout from auditing #166: CI could not have caught that bug, and still can't catch its whole class.

## What CI runs today

```yaml
- name: Test
  run: go test ./... -v
```

That's the entire gate. No `go vet`, no formatting check, no lint — despite the Makefile having had `fmt` and `lint` targets the whole time.

Two things this let through:

1. **`stacks/app_pipeline.go` and its test are unformatted on `main`** — misaligned struct tags from #164. `gofmt -l` and `golangci-lint fmt --diff` both flag them. Fixed here.
2. **The `--json`/`-j` collision that broke `db load` for six weeks** went unchallenged through review and CI. (Test coverage for that specific class is #168; this PR is the surrounding gate.)

## What this adds

A `checks` job running `go vet ./...` and `golangci-lint fmt --diff`. Both pass on `main` once the drift in item 1 is corrected — which is why the formatting fix is bundled rather than split out. Adding the check without the fix would land CI red.

Two implementation notes:

- **Same tool and subcommand as `make fmt`**, so a clean local run is a clean CI run. No second source of truth for formatting.
- **`golangci-lint-action` is not usable here.** It only ever invokes `golangci-lint run` — there's no input to select the `fmt` subcommand, and `args: fmt --diff` would just be appended to `run`. Installing the pinned binary explicitly is the working approach. Verified `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3` resolves and that `fmt --diff` exits 1 on drift, 0 when clean.

## Deliberately not included

`golangci-lint run` — it currently reports ~29 pre-existing `errcheck` findings (mostly unchecked `MarkPersistentFlagRequired` and `fmt.Fprintln` returns). Gating on it means triaging those first. Worth doing, but not as a drive-by.

Refs #166
